### PR TITLE
Treat null as Option::None when parsing json.

### DIFF
--- a/src/definitions/traits/from_json.rs
+++ b/src/definitions/traits/from_json.rs
@@ -190,4 +190,12 @@ mod tests {
 
         assert!(s.a.is_none());
     }
+
+    #[test]
+    fn int_as_some() {
+        let v: Value = json!({ "a": 11 });
+        let s = S::from_json(&v).unwrap();
+
+        assert!(s.a.is_some());
+    }
 }


### PR DESCRIPTION
Self explanatory I think.