### PR TITLE
Fix macro use externally to isomdl.

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -56,6 +56,32 @@ fn is_optional(ty: &Type) -> bool {
     }
 }
 
+// Attribute for setting the path to the isomdl crate, mostly for use
+// internally in isomdl to refer to itself as 'crate'.
+fn crate_path(attr: &Attribute) -> Option<String> {
+    get_isomdl_attributes(attr)?
+        .filter_map(|nested_meta| {
+            let meta = match nested_meta {
+                NestedMeta::Meta(meta) => meta,
+                _ => return None,
+            };
+            match meta {
+                Meta::NameValue(pair) => {
+                    if !pair.path.is_ident("crate") {
+                        return None;
+                    }
+                    if let Lit::Str(s) = pair.lit {
+                        Some(s.value())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        })
+        .next()
+}
+
 fn rename(attr: &Attribute) -> Option<String> {
     get_isomdl_attributes(attr)?
         .filter_map(|nested_meta| {

--- a/src/definitions/namespaces/org_iso_18013_5_1/driving_privileges.rs
+++ b/src/definitions/namespaces/org_iso_18013_5_1/driving_privileges.rs
@@ -7,6 +7,7 @@ use serde_cbor::Value as Cbor;
 
 /// `driving_privileges` in the org.iso.18013.5.1 namespace.
 #[derive(Clone, Debug, FromJson)]
+#[isomdl(crate = "crate")]
 pub struct DrivingPrivileges(Vec<DrivingPrivilege>);
 
 impl From<DrivingPrivileges> for Cbor {
@@ -16,6 +17,7 @@ impl From<DrivingPrivileges> for Cbor {
 }
 
 #[derive(Clone, Debug, FromJson, ToCbor)]
+#[isomdl(crate = "crate")]
 pub struct DrivingPrivilege {
     pub vehicle_category_code: String,
     pub issue_date: Option<FullDate>,
@@ -24,6 +26,7 @@ pub struct DrivingPrivilege {
 }
 
 #[derive(Clone, Debug, FromJson)]
+#[isomdl(crate = "crate")]
 pub struct Codes(NonEmptyVec<Code>);
 
 impl From<Codes> for Cbor {
@@ -33,6 +36,7 @@ impl From<Codes> for Cbor {
 }
 
 #[derive(Clone, Debug, FromJson, ToCbor)]
+#[isomdl(crate = "crate")]
 pub struct Code {
     pub code: String,
     pub sign: Option<String>,

--- a/src/definitions/namespaces/org_iso_18013_5_1/mod.rs
+++ b/src/definitions/namespaces/org_iso_18013_5_1/mod.rs
@@ -29,6 +29,7 @@ use crate::{
 
 /// The `org.iso.18013.5.1` namespace.
 #[derive(Debug, Clone, FromJson, ToCbor)]
+#[isomdl(crate = "crate")]
 pub struct OrgIso1801351 {
     pub family_name: Latin1,
     pub given_name: Latin1,

--- a/src/definitions/namespaces/org_iso_18013_5_1_aamva/domestic_driving_privileges.rs
+++ b/src/definitions/namespaces/org_iso_18013_5_1_aamva/domestic_driving_privileges.rs
@@ -8,6 +8,7 @@ use serde_cbor::Value as Cbor;
 /// `domestic_driving_privileges` in the org.iso.18013.5.1.aamva namespace, as per the AAMVA mDL Implementation
 /// Guidelines (Version 1.0).
 #[derive(Clone, Debug, FromJson)]
+#[isomdl(crate = "crate")]
 pub struct DomesticDrivingPrivileges(Vec<DomesticDrivingPrivilege>);
 
 impl ToCbor for DomesticDrivingPrivileges {
@@ -17,6 +18,7 @@ impl ToCbor for DomesticDrivingPrivileges {
 }
 
 #[derive(Clone, Debug, FromJson, ToCbor)]
+#[isomdl(crate = "crate")]
 pub struct DomesticDrivingPrivilege {
     pub domestic_vehicle_class: Option<DomesticVehicleClass>,
     pub domestic_vehicle_restrictions: Option<DomesticVehicleRestrictions>,
@@ -24,6 +26,7 @@ pub struct DomesticDrivingPrivilege {
 }
 
 #[derive(Clone, Debug, FromJson, ToCbor)]
+#[isomdl(crate = "crate")]
 pub struct DomesticVehicleClass {
     pub domestic_vehicle_class_code: String,
     pub domestic_vehicle_class_description: String,
@@ -32,6 +35,7 @@ pub struct DomesticVehicleClass {
 }
 
 #[derive(Clone, Debug, FromJson)]
+#[isomdl(crate = "crate")]
 pub struct DomesticVehicleRestrictions(NonEmptyVec<DomesticVehicleRestriction>);
 
 impl ToCbor for DomesticVehicleRestrictions {
@@ -47,12 +51,14 @@ impl ToCbor for DomesticVehicleRestrictions {
 }
 
 #[derive(Clone, Debug, FromJson, ToCbor)]
+#[isomdl(crate = "crate")]
 pub struct DomesticVehicleRestriction {
     pub domestic_vehicle_restriction_code: Option<String>,
     pub domestic_vehicle_restriction_description: String,
 }
 
 #[derive(Clone, Debug, FromJson)]
+#[isomdl(crate = "crate")]
 pub struct DomesticVehicleEndorsements(NonEmptyVec<DomesticVehicleEndorsement>);
 
 impl ToCbor for DomesticVehicleEndorsements {
@@ -68,6 +74,7 @@ impl ToCbor for DomesticVehicleEndorsements {
 }
 
 #[derive(Clone, Debug, FromJson, ToCbor)]
+#[isomdl(crate = "crate")]
 pub struct DomesticVehicleEndorsement {
     pub domestic_vehicle_endorsement_code: Option<String>,
     pub domestic_vehicle_endorsement_description: String,

--- a/src/definitions/namespaces/org_iso_18013_5_1_aamva/mod.rs
+++ b/src/definitions/namespaces/org_iso_18013_5_1_aamva/mod.rs
@@ -26,6 +26,7 @@ use crate::macros::{FromJson, ToCbor};
 /// `org.iso.18013.5.1.aamva` namespace, as per the AAMVA mDL Implementation
 /// Guidelines (Version 1.2).
 #[derive(Debug, Clone, FromJson, ToCbor)]
+#[isomdl(crate = "crate")]
 pub struct OrgIso1801351Aamva {
     pub domestic_driving_privileges: DomesticDrivingPrivileges,
     pub name_suffix: Option<NameSuffix>,

--- a/src/definitions/traits/from_json.rs
+++ b/src/definitions/traits/from_json.rs
@@ -179,6 +179,7 @@ mod tests {
     use serde_json::{json, Value};
 
     #[derive(FromJson)]
+    #[isomdl(crate = "crate")]
     struct S {
         a: Option<u32>,
     }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use anyhow::{anyhow, Context, Result};
 use signature::Signer;
 use uuid::Uuid;

--- a/tests/namespace.rs
+++ b/tests/namespace.rs
@@ -1,0 +1,18 @@
+use isomdl::{
+    definitions::traits::FromJson,
+    macros::{FromJson, ToCbor},
+};
+
+#[derive(FromJson, ToCbor)]
+pub struct NewNamespace {
+    field: String,
+}
+
+#[test]
+fn new_namespace() {
+    let json = serde_json::json!({
+        "field": "value"
+    });
+
+    NewNamespace::from_json(&json).unwrap();
+}


### PR DESCRIPTION
Add macro attribute to select path to isomdl crate, and use "crate" as the path internally.