### PR TITLE
Transform `DrivingPrivilege::vehicle_category_code` to an `enum`. Additional: make sure we handle `UPPERCASE` `JSONvalues` for `EyeColour` and `HairColour.`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ isomdl-macros = { version = "0.1.0", path = "macros" }
 clap = { version = "4", features = ["derive"] }
 clap-stdin = "0.2.1"
 
+strum = "0.24"
+strum_macros = "0.24"
+
 [dependencies.cose-rs]
 git = "https://github.com/spruceid/cose-rs"
 rev = "4104505"
@@ -51,4 +54,3 @@ rev = "4104505"
 hex = "0.4.3"
 p256 = "0.13.0"
 serde_json = "*"
-

--- a/src/definitions/namespaces/org_iso_18013_5_1/driving_privileges.rs
+++ b/src/definitions/namespaces/org_iso_18013_5_1/driving_privileges.rs
@@ -1,9 +1,13 @@
 use super::FullDate;
 use crate::{
-    definitions::{helpers::NonEmptyVec, traits::ToCbor},
+    definitions::{
+        helpers::NonEmptyVec,
+        traits::{FromJsonError, ToCbor},
+    },
     macros::{FromJson, ToCbor},
 };
 use serde_cbor::Value as Cbor;
+use strum_macros::{AsRefStr, EnumString, EnumVariantNames};
 
 /// `driving_privileges` in the org.iso.18013.5.1 namespace.
 #[derive(Clone, Debug, FromJson)]
@@ -15,9 +19,60 @@ impl From<DrivingPrivileges> for Cbor {
     }
 }
 
+/// The specifications of vehicle categories and restrictions
+#[derive(Clone, EnumString, Debug, EnumVariantNames, AsRefStr)]
+pub enum VehicleCategoryCode {
+    /// Motorcycles
+    A,
+    /// Light vehicles
+    B,
+    /// Goods vehicles
+    C,
+    // Passenger vehicles
+    D,
+    /// Light vehicles with trailers
+    BE,
+    /// Goods vehicles with trailers
+    CE,
+    /// Passenger vehicles with trailers
+    DE,
+    ///Mopeds
+    AM,
+    /// Light motorcycles
+    A1,
+    /// Medium motorcycles
+    A2,
+    /// Light vehicles
+    B1,
+    /// Medium sized goods vehicles
+    C1,
+    /// Medium sized passenger vehicles (e.g.minibuses)
+    D1,
+    /// Medium sized goods vehicles with trailers
+    C1E,
+    /// Medium sized passenger vehicles (e.g. minibuses) with trailers
+    D1E,
+}
+
+impl From<VehicleCategoryCode> for Cbor {
+    fn from(c: VehicleCategoryCode) -> Cbor {
+        Cbor::Text(c.as_ref().to_string())
+    }
+}
+
+impl crate::definitions::traits::FromJson for VehicleCategoryCode {
+    fn from_json(v: &serde_json::Value) -> Result<Self, FromJsonError> {
+        v.as_str()
+            .map(str::to_uppercase)
+            .map(|s| s.parse::<VehicleCategoryCode>())
+            .unwrap_or(Err(strum::ParseError::VariantNotFound))
+            .map_err(|_| FromJsonError::Missing)
+    }
+}
+
 #[derive(Clone, Debug, FromJson, ToCbor)]
 pub struct DrivingPrivilege {
-    pub vehicle_category_code: String,
+    pub vehicle_category_code: VehicleCategoryCode,
     pub issue_date: Option<FullDate>,
     pub expiry_date: Option<FullDate>,
     pub codes: Option<Codes>,

--- a/src/definitions/namespaces/org_iso_18013_5_1/eye_colour.rs
+++ b/src/definitions/namespaces/org_iso_18013_5_1/eye_colour.rs
@@ -51,7 +51,7 @@ impl FromStr for EyeColour {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Error> {
-        match s {
+        match s.to_lowercase().as_str() {
             "black" => Ok(Self::Black),
             "blue" => Ok(Self::Blue),
             "brown" => Ok(Self::Brown),

--- a/src/definitions/namespaces/org_iso_18013_5_1/hair_colour.rs
+++ b/src/definitions/namespaces/org_iso_18013_5_1/hair_colour.rs
@@ -51,7 +51,7 @@ impl FromStr for HairColour {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Error> {
-        match s {
+        match s.to_lowercase().as_str() {
             "bald" => Ok(Self::Bald),
             "black" => Ok(Self::Black),
             "blond" => Ok(Self::Blond),


### PR DESCRIPTION
Transform DrivingPrivilege::vehicle_category_code to an enum to ensure we are using only valid values.  Additional: make sure we handle UPPERCASE JSONvalues for EyeColour and HairColour.