### PR TITLE
Expose document types in ResponseAuthenticationOutcome

### DIFF
--- a/src/presentation/authentication/mod.rs
+++ b/src/presentation/authentication/mod.rs
@@ -32,6 +32,8 @@ pub struct RequestAuthenticationOutcome {
 pub struct ResponseAuthenticationOutcome {
     /// The values sent back from the holder device, serialized as JSON.
     pub response: BTreeMap<String, Value>,
+    /// Document types (doctypes) from the presented credentials.
+    pub doc_types: Vec<String>,
     /// Outcome of issuer authentication.
     pub issuer_authentication: AuthenticationStatus,
     /// Outcome of device authentication.

--- a/src/presentation/reader.rs
+++ b/src/presentation/reader.rs
@@ -454,6 +454,13 @@ impl SessionManager {
             }
         };
 
+        // Extract doc_types from the decrypted device response
+        let doc_types: Vec<String> = device_response
+            .documents
+            .as_ref()
+            .map(|docs| docs.iter().map(|d| d.doc_type.clone()).collect())
+            .unwrap_or_default();
+
         match parse(&device_response) {
             Ok((document, x5chain, namespaces)) => {
                 validate_response(
@@ -462,11 +469,13 @@ impl SessionManager {
                     x5chain,
                     document.clone(),
                     namespaces,
+                    doc_types,
                     revocation_fetcher,
                 )
                 .await
             }
             Err(e) => {
+                validated_response.doc_types = doc_types;
                 validated_response
                     .errors
                     .insert("parsing_errors".to_string(), json!(vec![format!("{e}")]));

--- a/src/presentation/reader_utils.rs
+++ b/src/presentation/reader_utils.rs
@@ -22,6 +22,7 @@ use super::authentication::{
 /// * `x5chain` - The certificate chain to validate
 /// * `document` - The document to validate
 /// * `namespaces` - The namespaces from the response
+/// * `doc_types` - The document types from the response
 /// * `revocation_fetcher` - Revocation fetcher for CRL checking. Use `&()` to skip revocation checks.
 pub async fn validate_response<S, R>(
     session_transcript: S,
@@ -29,6 +30,7 @@ pub async fn validate_response<S, R>(
     x5chain: X5Chain,
     document: Document,
     namespaces: BTreeMap<String, serde_json::Value>,
+    doc_types: Vec<String>,
     revocation_fetcher: &R,
 ) -> ResponseAuthenticationOutcome
 where
@@ -37,6 +39,7 @@ where
 {
     let mut validated_response = ResponseAuthenticationOutcome {
         response: namespaces,
+        doc_types,
         ..Default::default()
     };
 


### PR DESCRIPTION
After decrypting and parsing a device response, the reader has no way to know the document types (doctypes) of the presented credentials. The `doc_type` field is available in the `DeviceResponse.documents` but was not being exposed in the `ResponseAuthenticationOutcome`.

This is needed to display appropriate credential names in verifier UIs (e.g., "Mobile Driver's License" vs "Age Verification" vs "EU Personal ID") based on the actual doctype, rather than hardcoding or inferring from namespaces.
