### PR TITLE
add device authentication device mac validation for reader

### DIFF
--- a/src/definitions/session.rs
+++ b/src/definitions/session.rs
@@ -244,8 +244,8 @@ pub fn derive_e_mac_key<T: serde::Serialize>(
     );
     let hkdf = shared_secret.extract::<Sha256>(Some(salt.as_ref()));
     let mut okm = [0u8; 32];
-    // Safe to unwrap as error will only occur if okm.len() is greater than 255 * 32;
-    Hkdf::expand(&hkdf, b"EMacKey", &mut okm).unwrap();
+    Hkdf::expand(&hkdf, b"EMacKey", &mut okm)
+        .map_err(|e| anyhow::anyhow!("HKDF expand failed: {e}"))?;
     Ok(okm.into())
 }
 

--- a/src/definitions/session.rs
+++ b/src/definitions/session.rs
@@ -227,13 +227,16 @@ pub fn derive_session_key(
     Ok(okm.into())
 }
 
-/// Derive the EMacKey from the shared secret per ISO 18013-5 section 9.1.1.5.
+/// Derive the EMacKey from the shared secret per ISO 18013-5 section 9.1.3.5.
 ///
 /// The EMacKey is used for HMAC-based device authentication (COSE_Mac0) as an
 /// alternative to ECDSA-based device authentication (COSE_Sign1).
-pub fn derive_e_mac_key(
+///
+/// The shared secret must be derived using ECDH with the mdoc authentication key (SDeviceKey)
+/// and the reader's ephemeral key (EReaderKey), not the ephemeral device session key.
+pub fn derive_e_mac_key<T: serde::Serialize>(
     shared_secret: &SharedSecret<NistP256>,
-    session_transcript: &SessionTranscriptBytes,
+    session_transcript: &Tag24<T>,
 ) -> Result<GenericArray<u8, U32>> {
     let salt = Sha256::digest(
         crate::cbor::to_vec(session_transcript)

--- a/src/definitions/session.rs
+++ b/src/definitions/session.rs
@@ -227,6 +227,25 @@ pub fn derive_session_key(
     Ok(okm.into())
 }
 
+/// Derive the EMacKey from the shared secret per ISO 18013-5 section 9.1.1.5.
+///
+/// The EMacKey is used for HMAC-based device authentication (COSE_Mac0) as an
+/// alternative to ECDSA-based device authentication (COSE_Sign1).
+pub fn derive_e_mac_key(
+    shared_secret: &SharedSecret<NistP256>,
+    session_transcript: &SessionTranscriptBytes,
+) -> Result<GenericArray<u8, U32>> {
+    let salt = Sha256::digest(
+        crate::cbor::to_vec(session_transcript)
+            .map_err(|e| anyhow::anyhow!("failed to serialize session transcript: {e}"))?,
+    );
+    let hkdf = shared_secret.extract::<Sha256>(Some(salt.as_ref()));
+    let mut okm = [0u8; 32];
+    // Safe to unwrap as error will only occur if okm.len() is greater than 255 * 32;
+    Hkdf::expand(&hkdf, b"EMacKey", &mut okm).unwrap();
+    Ok(okm.into())
+}
+
 pub fn encrypt_device_data(
     sk_device: &GenericArray<u8, U32>,
     plaintext: &[u8],

--- a/src/presentation/authentication/mdoc.rs
+++ b/src/presentation/authentication/mdoc.rs
@@ -87,76 +87,68 @@ where
     let cbor_payload = cbor::to_vec(&detached_payload)?;
 
     match device_auth {
-        DeviceAuth::DeviceSignature(device_signature) => {
-            match jwk.params {
-                Params::EC(ref p) => {
-                    let x_coordinate = p.x_coordinate.clone();
-                    let y_coordinate = p.y_coordinate.clone();
-                    let (Some(x), Some(y)) = (x_coordinate, y_coordinate) else {
-                        return Err(Error::MdocAuth(
-                            "device key jwk is missing coordinates".to_string(),
-                        ));
-                    };
+        DeviceAuth::DeviceSignature(device_signature) => match jwk.params {
+            Params::EC(ref p) => {
+                let x_coordinate = p.x_coordinate.clone();
+                let y_coordinate = p.y_coordinate.clone();
+                let (Some(x), Some(y)) = (x_coordinate, y_coordinate) else {
+                    return Err(Error::MdocAuth(
+                        "device key jwk is missing coordinates".to_string(),
+                    ));
+                };
 
-                    let curve_name = p.curve.as_ref().ok_or_else(|| {
-                        Error::MdocAuth("device key JWK missing 'crv' parameter".to_string())
-                    })?;
+                let curve_name = p.curve.as_ref().ok_or_else(|| {
+                    Error::MdocAuth("device key JWK missing 'crv' parameter".to_string())
+                })?;
 
-                    let curve = SupportedCurve::from_jwk_crv(curve_name)
-                        .ok_or_else(|| {
-                            Error::MdocAuth(format!("unsupported curve: {curve_name}"))
-                        })?;
+                let curve = SupportedCurve::from_jwk_crv(curve_name)
+                    .ok_or_else(|| Error::MdocAuth(format!("unsupported curve: {curve_name}")))?;
 
-                    let result = match curve {
-                        SupportedCurve::P256 => {
-                            let encoded_point = p256::EncodedPoint::from_affine_coordinates(
-                                GenericArray::from_slice(x.0.as_slice()),
-                                GenericArray::from_slice(y.0.as_slice()),
-                                false,
-                            );
-                            let verifying_key =
-                                ecdsa::VerifyingKey::<NistP256>::from_encoded_point(
-                                    &encoded_point,
-                                )?;
-                            device_signature
-                                .verify::<ecdsa::VerifyingKey<NistP256>, p256::ecdsa::Signature>(
-                                    &verifying_key,
-                                    Some(&cbor_payload),
-                                    None,
-                                )
-                        }
-                        SupportedCurve::P384 => {
-                            let encoded_point = p384::EncodedPoint::from_affine_coordinates(
-                                GenericArray::from_slice(x.0.as_slice()),
-                                GenericArray::from_slice(y.0.as_slice()),
-                                false,
-                            );
-                            let verifying_key =
-                                ecdsa::VerifyingKey::<NistP384>::from_encoded_point(
-                                    &encoded_point,
-                                )?;
-                            device_signature
-                                .verify::<ecdsa::VerifyingKey<NistP384>, p384::ecdsa::Signature>(
-                                    &verifying_key,
-                                    Some(&cbor_payload),
-                                    None,
-                                )
-                        }
-                    };
-
-                    match result {
-                        VerificationResult::Success => Ok(()),
-                        VerificationResult::Failure(e) => Err(Error::MdocAuth(format!(
-                            "failed verifying device signature: {e}"
-                        ))),
-                        VerificationResult::Error(e) => Err(Error::MdocAuth(format!(
-                            "error verifying device signature: {e}"
-                        ))),
+                let result = match curve {
+                    SupportedCurve::P256 => {
+                        let encoded_point = p256::EncodedPoint::from_affine_coordinates(
+                            GenericArray::from_slice(x.0.as_slice()),
+                            GenericArray::from_slice(y.0.as_slice()),
+                            false,
+                        );
+                        let verifying_key =
+                            ecdsa::VerifyingKey::<NistP256>::from_encoded_point(&encoded_point)?;
+                        device_signature
+                            .verify::<ecdsa::VerifyingKey<NistP256>, p256::ecdsa::Signature>(
+                                &verifying_key,
+                                Some(&cbor_payload),
+                                None,
+                            )
                     }
+                    SupportedCurve::P384 => {
+                        let encoded_point = p384::EncodedPoint::from_affine_coordinates(
+                            GenericArray::from_slice(x.0.as_slice()),
+                            GenericArray::from_slice(y.0.as_slice()),
+                            false,
+                        );
+                        let verifying_key =
+                            ecdsa::VerifyingKey::<NistP384>::from_encoded_point(&encoded_point)?;
+                        device_signature
+                            .verify::<ecdsa::VerifyingKey<NistP384>, p384::ecdsa::Signature>(
+                                &verifying_key,
+                                Some(&cbor_payload),
+                                None,
+                            )
+                    }
+                };
+
+                match result {
+                    VerificationResult::Success => Ok(()),
+                    VerificationResult::Failure(e) => Err(Error::MdocAuth(format!(
+                        "failed verifying device signature: {e}"
+                    ))),
+                    VerificationResult::Error(e) => Err(Error::MdocAuth(format!(
+                        "error verifying device signature: {e}"
+                    ))),
                 }
-                _ => Err(Error::MdocAuth("Unsupported device_key type".to_string())),
             }
-        }
+            _ => Err(Error::MdocAuth("Unsupported device_key type".to_string())),
+        },
         DeviceAuth::DeviceMac(device_mac) => {
             let e_mac_key = e_mac_key.ok_or_else(|| {
                 Error::MdocAuth("DeviceMac received but no EMacKey available".to_string())
@@ -168,12 +160,12 @@ where
 
             match result {
                 Mac0VerificationResult::Success => Ok(()),
-                Mac0VerificationResult::Failure(e) => Err(Error::MdocAuth(format!(
-                    "failed verifying device mac: {e}"
-                ))),
-                Mac0VerificationResult::Error(e) => Err(Error::MdocAuth(format!(
-                    "error verifying device mac: {e}"
-                ))),
+                Mac0VerificationResult::Failure(e) => {
+                    Err(Error::MdocAuth(format!("failed verifying device mac: {e}")))
+                }
+                Mac0VerificationResult::Error(e) => {
+                    Err(Error::MdocAuth(format!("error verifying device mac: {e}")))
+                }
             }
         }
     }

--- a/src/presentation/authentication/mdoc.rs
+++ b/src/presentation/authentication/mdoc.rs
@@ -1,4 +1,5 @@
 use crate::cbor;
+use crate::cose::mac0::VerificationResult as Mac0VerificationResult;
 use crate::cose::sign1::VerificationResult;
 use crate::definitions::device_response::Document;
 use crate::definitions::issuer_signed;
@@ -9,10 +10,13 @@ use crate::definitions::Mso;
 use crate::definitions::{device_signed::DeviceAuthentication, helpers::Tag24};
 use crate::presentation::reader::Error;
 use anyhow::Result;
+use digest::Mac;
 use elliptic_curve::generic_array::GenericArray;
+use hmac::Hmac;
 use issuer_signed::IssuerSigned;
 use p256::NistP256;
 use p384::NistP384;
+use sha2::Sha256;
 use ssi_jwk::Params;
 use ssi_jwk::JWK as SsiJwk;
 
@@ -53,7 +57,11 @@ pub fn issuer_authentication(x5chain: X5Chain, issuer_signed: &IssuerSigned) -> 
         .map_err(Error::IssuerAuthentication)
 }
 
-pub fn device_authentication<S>(document: &Document, session_transcript: S) -> Result<(), Error>
+pub fn device_authentication<S>(
+    document: &Document,
+    session_transcript: S,
+    e_mac_key: Option<&[u8; 32]>,
+) -> Result<(), Error>
 where
     S: SessionTranscript + Clone,
 {
@@ -67,82 +75,106 @@ where
     let device_key = mso.into_inner().device_key_info.device_key;
     let jwk = SsiJwk::try_from(device_key)?;
 
-    match jwk.params {
-        Params::EC(ref p) => {
-            let x_coordinate = p.x_coordinate.clone();
-            let y_coordinate = p.y_coordinate.clone();
-            let (Some(x), Some(y)) = (x_coordinate, y_coordinate) else {
-                return Err(Error::MdocAuth(
-                    "device key jwk is missing coordinates".to_string(),
-                ));
-            };
+    let namespaces_bytes = &document.device_signed.namespaces;
+    let device_auth: &DeviceAuth = &document.device_signed.device_auth;
 
-            let namespaces_bytes = &document.device_signed.namespaces;
-            let device_auth: &DeviceAuth = &document.device_signed.device_auth;
+    let detached_payload = Tag24::new(DeviceAuthentication::new(
+        session_transcript,
+        document.doc_type.clone(),
+        namespaces_bytes.clone(),
+    ))
+    .map_err(|_| Error::CborDecodingError)?;
+    let cbor_payload = cbor::to_vec(&detached_payload)?;
 
-            let DeviceAuth::DeviceSignature(device_signature) = device_auth else {
-                return Err(Error::Unsupported);
-            };
+    match device_auth {
+        DeviceAuth::DeviceSignature(device_signature) => {
+            match jwk.params {
+                Params::EC(ref p) => {
+                    let x_coordinate = p.x_coordinate.clone();
+                    let y_coordinate = p.y_coordinate.clone();
+                    let (Some(x), Some(y)) = (x_coordinate, y_coordinate) else {
+                        return Err(Error::MdocAuth(
+                            "device key jwk is missing coordinates".to_string(),
+                        ));
+                    };
 
-            let detached_payload = Tag24::new(DeviceAuthentication::new(
-                session_transcript,
-                document.doc_type.clone(),
-                namespaces_bytes.clone(),
-            ))
-            .map_err(|_| Error::CborDecodingError)?;
-            let cbor_payload = cbor::to_vec(&detached_payload)?;
+                    let curve_name = p.curve.as_ref().ok_or_else(|| {
+                        Error::MdocAuth("device key JWK missing 'crv' parameter".to_string())
+                    })?;
 
-            // Determine curve from JWK and verify accordingly
-            let curve_name = p.curve.as_ref().ok_or_else(|| {
-                Error::MdocAuth("device key JWK missing 'crv' parameter".to_string())
+                    let curve = SupportedCurve::from_jwk_crv(curve_name)
+                        .ok_or_else(|| {
+                            Error::MdocAuth(format!("unsupported curve: {curve_name}"))
+                        })?;
+
+                    let result = match curve {
+                        SupportedCurve::P256 => {
+                            let encoded_point = p256::EncodedPoint::from_affine_coordinates(
+                                GenericArray::from_slice(x.0.as_slice()),
+                                GenericArray::from_slice(y.0.as_slice()),
+                                false,
+                            );
+                            let verifying_key =
+                                ecdsa::VerifyingKey::<NistP256>::from_encoded_point(
+                                    &encoded_point,
+                                )?;
+                            device_signature
+                                .verify::<ecdsa::VerifyingKey<NistP256>, p256::ecdsa::Signature>(
+                                    &verifying_key,
+                                    Some(&cbor_payload),
+                                    None,
+                                )
+                        }
+                        SupportedCurve::P384 => {
+                            let encoded_point = p384::EncodedPoint::from_affine_coordinates(
+                                GenericArray::from_slice(x.0.as_slice()),
+                                GenericArray::from_slice(y.0.as_slice()),
+                                false,
+                            );
+                            let verifying_key =
+                                ecdsa::VerifyingKey::<NistP384>::from_encoded_point(
+                                    &encoded_point,
+                                )?;
+                            device_signature
+                                .verify::<ecdsa::VerifyingKey<NistP384>, p384::ecdsa::Signature>(
+                                    &verifying_key,
+                                    Some(&cbor_payload),
+                                    None,
+                                )
+                        }
+                    };
+
+                    match result {
+                        VerificationResult::Success => Ok(()),
+                        VerificationResult::Failure(e) => Err(Error::MdocAuth(format!(
+                            "failed verifying device signature: {e}"
+                        ))),
+                        VerificationResult::Error(e) => Err(Error::MdocAuth(format!(
+                            "error verifying device signature: {e}"
+                        ))),
+                    }
+                }
+                _ => Err(Error::MdocAuth("Unsupported device_key type".to_string())),
+            }
+        }
+        DeviceAuth::DeviceMac(device_mac) => {
+            let e_mac_key = e_mac_key.ok_or_else(|| {
+                Error::MdocAuth("DeviceMac received but no EMacKey available".to_string())
             })?;
+            let verifier = Hmac::<Sha256>::new_from_slice(e_mac_key.as_slice())
+                .map_err(|e| Error::MdocAuth(format!("failed to create HMAC verifier: {e}")))?;
 
-            let curve = SupportedCurve::from_jwk_crv(curve_name)
-                .ok_or_else(|| Error::MdocAuth(format!("unsupported curve: {curve_name}")))?;
-
-            let result = match curve {
-                SupportedCurve::P256 => {
-                    let encoded_point = p256::EncodedPoint::from_affine_coordinates(
-                        GenericArray::from_slice(x.0.as_slice()),
-                        GenericArray::from_slice(y.0.as_slice()),
-                        false,
-                    );
-                    let verifying_key =
-                        ecdsa::VerifyingKey::<NistP256>::from_encoded_point(&encoded_point)?;
-                    device_signature
-                        .verify::<ecdsa::VerifyingKey<NistP256>, p256::ecdsa::Signature>(
-                            &verifying_key,
-                            Some(&cbor_payload),
-                            None,
-                        )
-                }
-                SupportedCurve::P384 => {
-                    let encoded_point = p384::EncodedPoint::from_affine_coordinates(
-                        GenericArray::from_slice(x.0.as_slice()),
-                        GenericArray::from_slice(y.0.as_slice()),
-                        false,
-                    );
-                    let verifying_key =
-                        ecdsa::VerifyingKey::<NistP384>::from_encoded_point(&encoded_point)?;
-                    device_signature
-                        .verify::<ecdsa::VerifyingKey<NistP384>, p384::ecdsa::Signature>(
-                            &verifying_key,
-                            Some(&cbor_payload),
-                            None,
-                        )
-                }
-            };
+            let result = device_mac.verify(&verifier, Some(&cbor_payload), None);
 
             match result {
-                VerificationResult::Success => Ok(()),
-                VerificationResult::Failure(e) => Err(Error::MdocAuth(format!(
-                    "failed verifying device signature: {e}"
+                Mac0VerificationResult::Success => Ok(()),
+                Mac0VerificationResult::Failure(e) => Err(Error::MdocAuth(format!(
+                    "failed verifying device mac: {e}"
                 ))),
-                VerificationResult::Error(e) => Err(Error::MdocAuth(format!(
-                    "error verifying device signature: {e}"
+                Mac0VerificationResult::Error(e) => Err(Error::MdocAuth(format!(
+                    "error verifying device mac: {e}"
                 ))),
             }
         }
-        _ => Err(Error::MdocAuth("Unsupported device_key type".to_string())),
     }
 }

--- a/src/presentation/authentication/mdoc.rs
+++ b/src/presentation/authentication/mdoc.rs
@@ -152,11 +152,12 @@ where
             _ => Err(Error::MdocAuth("Unsupported device_key type".to_string())),
         },
         DeviceAuth::DeviceMac(device_mac) => {
-            let priv_key_bytes = e_reader_key_private;
-            // Per ISO 18013-5 §9.1.3.5, EMacKey uses ECDH with the mdoc authentication key
+            // MAC authentication is only defined for cipher suite 1 (ISO 18013-5 §9.1.3.5),
+            // which uses P-256. Other curves are not supported for COSE_Mac0.
+            // Per §9.1.3.5, EMacKey uses ECDH with the mdoc authentication key
             // (SDeviceKey, the static key from the MSO) — not the ephemeral session key.
             let private_key =
-                p256::SecretKey::from_bytes(FieldBytes::from_slice(priv_key_bytes))
+                p256::SecretKey::from_bytes(FieldBytes::from_slice(e_reader_key_private))
                     .map_err(|e| Error::MdocAuth(format!("invalid reader private key: {e}")))?;
             let shared_secret = get_shared_secret(s_device_key, &private_key.into())
                 .map_err(|e| Error::MdocAuth(format!("ECDH with SDeviceKey failed: {e}")))?;

--- a/src/presentation/authentication/mdoc.rs
+++ b/src/presentation/authentication/mdoc.rs
@@ -3,7 +3,7 @@ use crate::cose::mac0::VerificationResult as Mac0VerificationResult;
 use crate::cose::sign1::VerificationResult;
 use crate::definitions::device_response::Document;
 use crate::definitions::issuer_signed;
-use crate::definitions::session::SessionTranscript;
+use crate::definitions::session::{derive_e_mac_key, get_shared_secret, SessionTranscript};
 use crate::definitions::x509::{SupportedCurve, X5Chain};
 use crate::definitions::DeviceAuth;
 use crate::definitions::Mso;
@@ -14,7 +14,7 @@ use digest::Mac;
 use elliptic_curve::generic_array::GenericArray;
 use hmac::Hmac;
 use issuer_signed::IssuerSigned;
-use p256::NistP256;
+use p256::{FieldBytes, NistP256};
 use p384::NistP384;
 use sha2::Sha256;
 use ssi_jwk::Params;
@@ -60,7 +60,7 @@ pub fn issuer_authentication(x5chain: X5Chain, issuer_signed: &IssuerSigned) -> 
 pub fn device_authentication<S>(
     document: &Document,
     session_transcript: S,
-    e_mac_key: Option<&[u8; 32]>,
+    e_reader_key_private: &[u8; 32],
 ) -> Result<(), Error>
 where
     S: SessionTranscript + Clone,
@@ -73,13 +73,15 @@ where
         .ok_or(Error::DetachedIssuerAuth)?;
     let mso: Tag24<Mso> = cbor::from_slice(mso_bytes).map_err(|_| Error::MSOParsing)?;
     let device_key = mso.into_inner().device_key_info.device_key;
+    // Clone for MAC ECDH before consuming via JWK conversion
+    let s_device_key = device_key.clone();
     let jwk = SsiJwk::try_from(device_key)?;
 
     let namespaces_bytes = &document.device_signed.namespaces;
     let device_auth: &DeviceAuth = &document.device_signed.device_auth;
 
     let detached_payload = Tag24::new(DeviceAuthentication::new(
-        session_transcript,
+        session_transcript.clone(),
         document.doc_type.clone(),
         namespaces_bytes.clone(),
     ))
@@ -150,9 +152,18 @@ where
             _ => Err(Error::MdocAuth("Unsupported device_key type".to_string())),
         },
         DeviceAuth::DeviceMac(device_mac) => {
-            let e_mac_key = e_mac_key.ok_or_else(|| {
-                Error::MdocAuth("DeviceMac received but no EMacKey available".to_string())
-            })?;
+            let priv_key_bytes = e_reader_key_private;
+            // Per ISO 18013-5 §9.1.3.5, EMacKey uses ECDH with the mdoc authentication key
+            // (SDeviceKey, the static key from the MSO) — not the ephemeral session key.
+            let private_key =
+                p256::SecretKey::from_bytes(FieldBytes::from_slice(priv_key_bytes))
+                    .map_err(|e| Error::MdocAuth(format!("invalid reader private key: {e}")))?;
+            let shared_secret = get_shared_secret(s_device_key, &private_key.into())
+                .map_err(|e| Error::MdocAuth(format!("ECDH with SDeviceKey failed: {e}")))?;
+            let session_transcript_bytes =
+                Tag24::new(session_transcript.clone()).map_err(|_| Error::CborDecodingError)?;
+            let e_mac_key = derive_e_mac_key(&shared_secret, &session_transcript_bytes)
+                .map_err(|e| Error::MdocAuth(format!("failed to derive EMacKey: {e}")))?;
             let verifier = Hmac::<Sha256>::new_from_slice(e_mac_key.as_slice())
                 .map_err(|e| Error::MdocAuth(format!("failed to create HMAC verifier: {e}")))?;
 

--- a/src/presentation/device.rs
+++ b/src/presentation/device.rs
@@ -16,6 +16,10 @@
 //!
 //! You can view examples in `tests` directory in `simulated_device_and_reader.rs`, for a basic example and
 //! `simulated_device_and_reader_state.rs` which uses `State` pattern, `Arc` and `Mutex`.
+use digest::Mac;
+use hmac::Hmac;
+use sha2::Sha256;
+
 use crate::{
     cbor::{self, CborError},
     cose::{mac0::PreparedCoseMac0, sign1::PreparedCoseSign1, MaybeTagged},
@@ -128,8 +132,6 @@ pub struct SessionManager {
     state: State,
     trusted_verifiers: TrustAnchorRegistry,
     device_auth_type: DeviceAuthType,
-    #[serde(default)]
-    e_mac_key: Option<[u8; 32]>,
 }
 
 /// The internal states of the [SessionManager].
@@ -402,8 +404,6 @@ impl SessionManagerEngaged {
         let sk_reader = derive_session_key(&shared_secret, &session_transcript_bytes, true)?.into();
         let sk_device =
             derive_session_key(&shared_secret, &session_transcript_bytes, false)?.into();
-        let e_mac_key: [u8; 32] =
-            derive_e_mac_key(&shared_secret, &session_transcript_bytes)?.into();
 
         let mut sm = SessionManager {
             documents: self.documents,
@@ -415,7 +415,6 @@ impl SessionManagerEngaged {
             state: State::AwaitingRequest,
             trusted_verifiers,
             device_auth_type: DeviceAuthType::Sign1,
-            e_mac_key: Some(e_mac_key),
         };
 
         let validated_request = sm
@@ -433,31 +432,33 @@ impl SessionManagerEngaged {
 }
 
 impl SessionManager {
-    /// Set the device authentication type.
+    /// Prepare a Mac0 response using HMAC-SHA256 device authentication (ISO 18013-5 §9.1.3.5).
     ///
-    /// Defaults to `DeviceAuthType::Sign1`. Set to `DeviceAuthType::Mac0` to use
-    /// HMAC-based device authentication. When using `Mac0`, the signature payload
-    /// from [`get_next_signature_payload`](Self::get_next_signature_payload) should
-    /// be tagged with `HMAC-SHA256` using the key from [`e_mac_key`](Self::e_mac_key).
-    pub fn set_device_auth_type(&mut self, device_auth_type: DeviceAuthType) {
-        self.device_auth_type = device_auth_type;
+    /// Derives EMacKey via `ECDH(static_key, EReaderKey) + HKDF`, computes all HMAC-SHA256 tags,
+    /// and advances state to `ReadyToRespond`. Call [`retrieve_response`](Self::retrieve_response)
+    /// afterwards to obtain the encrypted response bytes.
+    pub fn prepare_response_mac0(
+        &mut self,
+        requests: &RequestedItems,
+        permitted: PermittedItems,
+        static_key: &p256::NonZeroScalar,
+    ) -> anyhow::Result<()> {
+        let e_mac_key = self.compute_e_mac_key_from_static_key(static_key)?;
+        self.device_auth_type = DeviceAuthType::Mac0;
+        let prepared_response = DeviceSession::prepare_response(self, requests, permitted);
+        self.state = State::Signing(prepared_response);
+        while let Some(payload) = self.get_next_signature_payload().map(|(_, p)| p.to_vec()) {
+            let mut mac = Hmac::<Sha256>::new_from_slice(&e_mac_key)
+                .map_err(|e| anyhow::anyhow!("failed to create HMAC key: {e}"))?;
+            mac.update(&payload);
+            let tag = mac.finalize().into_bytes().to_vec();
+            self.submit_next_signature(tag)?;
+        }
+        self.device_auth_type = DeviceAuthType::Sign1;
+        Ok(())
     }
 
-    /// Returns the EMacKey for HMAC-based device authentication.
-    ///
-    /// This key is derived from the ECDH shared secret during session establishment.
-    /// Use it with `HMAC-SHA256` to compute the tag for [`submit_next_signature`](Self::submit_next_signature)
-    /// when [`DeviceAuthType::Mac0`] is configured.
-    pub fn e_mac_key(&self) -> Option<&[u8; 32]> {
-        self.e_mac_key.as_ref()
-    }
-
-    /// Compute the EMacKey using the mdoc's static authentication key (SDeviceKey) per
-    /// ISO 18013-5 §9.1.3.5.
-    ///
-    /// This must be used instead of [`e_mac_key`](Self::e_mac_key) when the reader verifies
-    /// the COSE_Mac0 using the device authentication key from the MSO.
-    pub fn compute_e_mac_key_from_static_key(
+    fn compute_e_mac_key_from_static_key(
         &self,
         static_key: &p256::NonZeroScalar,
     ) -> anyhow::Result<[u8; 32]> {

--- a/src/presentation/device.rs
+++ b/src/presentation/device.rs
@@ -16,10 +16,6 @@
 //!
 //! You can view examples in `tests` directory in `simulated_device_and_reader.rs`, for a basic example and
 //! `simulated_device_and_reader_state.rs` which uses `State` pattern, `Arc` and `Mutex`.
-use digest::Mac;
-use hmac::Hmac;
-use sha2::Sha256;
-
 use crate::{
     cbor::{self, CborError},
     cose::{mac0::PreparedCoseMac0, sign1::PreparedCoseSign1, MaybeTagged},
@@ -432,33 +428,16 @@ impl SessionManagerEngaged {
 }
 
 impl SessionManager {
-    /// Prepare a Mac0 response using HMAC-SHA256 device authentication (ISO 18013-5 §9.1.3.5).
-    ///
-    /// Derives EMacKey via `ECDH(static_key, EReaderKey) + HKDF`, computes all HMAC-SHA256 tags,
-    /// and advances state to `ReadyToRespond`. Call [`retrieve_response`](Self::retrieve_response)
-    /// afterwards to obtain the encrypted response bytes.
-    pub fn prepare_response_mac0(
-        &mut self,
-        requests: &RequestedItems,
-        permitted: PermittedItems,
-        static_key: &p256::NonZeroScalar,
-    ) -> anyhow::Result<()> {
-        let e_mac_key = self.compute_e_mac_key_from_static_key(static_key)?;
-        self.device_auth_type = DeviceAuthType::Mac0;
-        let prepared_response = DeviceSession::prepare_response(self, requests, permitted);
-        self.state = State::Signing(prepared_response);
-        while let Some(payload) = self.get_next_signature_payload().map(|(_, p)| p.to_vec()) {
-            let mut mac = Hmac::<Sha256>::new_from_slice(&e_mac_key)
-                .map_err(|e| anyhow::anyhow!("failed to create HMAC key: {e}"))?;
-            mac.update(&payload);
-            let tag = mac.finalize().into_bytes().to_vec();
-            self.submit_next_signature(tag)?;
-        }
-        self.device_auth_type = DeviceAuthType::Sign1;
-        Ok(())
+    /// Set the device authentication type used when building the next response.
+    pub fn set_device_auth_type(&mut self, device_auth_type: DeviceAuthType) {
+        self.device_auth_type = device_auth_type;
     }
 
-    fn compute_e_mac_key_from_static_key(
+    /// Derive EMacKey for MAC0 device authentication (ISO 18013-5 §9.1.3.5).
+    ///
+    /// Computes `ECDH(static_key, EReaderKey)` followed by HKDF to produce the 32-byte key
+    /// used to compute HMAC-SHA256 tags in the signing loop.
+    pub fn e_mac_key_from_static_key(
         &self,
         static_key: &p256::NonZeroScalar,
     ) -> anyhow::Result<[u8; 32]> {
@@ -1108,6 +1087,9 @@ pub trait DeviceSession {
                     PreparedCose::Sign1(prepared_cose_sign1)
                 }
                 DeviceAuthType::Mac0 => {
+                    // MAC0 device authentication requires p256: EMacKey is derived via
+                    // ECDH(SDeviceKey, EReaderKey) + HKDF (ISO 18013-5 §9.1.3.5), which is
+                    // only defined for NistP256.
                     let header = coset::HeaderBuilder::new()
                         .algorithm(coset::iana::Algorithm::HMAC_256_256)
                         .build();

--- a/src/presentation/device.rs
+++ b/src/presentation/device.rs
@@ -452,6 +452,23 @@ impl SessionManager {
         self.e_mac_key.as_ref()
     }
 
+    /// Compute the EMacKey using the mdoc's static authentication key (SDeviceKey) per
+    /// ISO 18013-5 §9.1.3.5.
+    ///
+    /// This must be used instead of [`e_mac_key`](Self::e_mac_key) when the reader verifies
+    /// the COSE_Mac0 using the device authentication key from the MSO.
+    pub fn compute_e_mac_key_from_static_key(
+        &self,
+        static_key: &p256::NonZeroScalar,
+    ) -> anyhow::Result<[u8; 32]> {
+        let e_reader_key = self.session_transcript.1.clone().into_inner();
+        let shared_secret = get_shared_secret(e_reader_key, static_key)?;
+        let session_transcript_bytes = Tag24::new(self.session_transcript.clone())
+            .map_err(|e| anyhow::anyhow!("failed to encode session transcript: {e}"))?;
+        let key = derive_e_mac_key(&shared_secret, &session_transcript_bytes)?;
+        Ok(key.into())
+    }
+
     fn parse_request(&self, request: &[u8]) -> Result<DeviceRequest, PreparedDeviceResponse> {
         let request: ciborium::Value = cbor::from_slice(request).map_err(|error| {
             tracing::error!("unable to decode DeviceRequest bytes as cbor: {}", error);

--- a/src/presentation/device.rs
+++ b/src/presentation/device.rs
@@ -35,7 +35,8 @@ use crate::{
         helpers::{tag24, NonEmptyMap, NonEmptyVec, Tag24},
         issuer_signed::{IssuerSigned, IssuerSignedItemBytes},
         session::{
-            self, derive_session_key, get_shared_secret, Handover, SessionData, SessionTranscript,
+            self, derive_e_mac_key, derive_session_key, get_shared_secret, Handover, SessionData,
+            SessionTranscript,
         },
         x509::{
             self, revocation::RevocationFetcher, trust_anchor::TrustAnchorRegistry,
@@ -127,6 +128,8 @@ pub struct SessionManager {
     state: State,
     trusted_verifiers: TrustAnchorRegistry,
     device_auth_type: DeviceAuthType,
+    #[serde(default)]
+    e_mac_key: Option<[u8; 32]>,
 }
 
 /// The internal states of the [SessionManager].
@@ -399,6 +402,8 @@ impl SessionManagerEngaged {
         let sk_reader = derive_session_key(&shared_secret, &session_transcript_bytes, true)?.into();
         let sk_device =
             derive_session_key(&shared_secret, &session_transcript_bytes, false)?.into();
+        let e_mac_key: [u8; 32] = derive_e_mac_key(&shared_secret, &session_transcript_bytes)?
+            .into();
 
         let mut sm = SessionManager {
             documents: self.documents,
@@ -410,6 +415,7 @@ impl SessionManagerEngaged {
             state: State::AwaitingRequest,
             trusted_verifiers,
             device_auth_type: DeviceAuthType::Sign1,
+            e_mac_key: Some(e_mac_key),
         };
 
         let validated_request = sm
@@ -427,6 +433,25 @@ impl SessionManagerEngaged {
 }
 
 impl SessionManager {
+    /// Set the device authentication type.
+    ///
+    /// Defaults to `DeviceAuthType::Sign1`. Set to `DeviceAuthType::Mac0` to use
+    /// HMAC-based device authentication. When using `Mac0`, the signature payload
+    /// from [`get_next_signature_payload`](Self::get_next_signature_payload) should
+    /// be tagged with `HMAC-SHA256` using the key from [`e_mac_key`](Self::e_mac_key).
+    pub fn set_device_auth_type(&mut self, device_auth_type: DeviceAuthType) {
+        self.device_auth_type = device_auth_type;
+    }
+
+    /// Returns the EMacKey for HMAC-based device authentication.
+    ///
+    /// This key is derived from the ECDH shared secret during session establishment.
+    /// Use it with `HMAC-SHA256` to compute the tag for [`submit_next_signature`](Self::submit_next_signature)
+    /// when [`DeviceAuthType::Mac0`] is configured.
+    pub fn e_mac_key(&self) -> Option<&[u8; 32]> {
+        self.e_mac_key.as_ref()
+    }
+
     fn parse_request(&self, request: &[u8]) -> Result<DeviceRequest, PreparedDeviceResponse> {
         let request: ciborium::Value = cbor::from_slice(request).map_err(|error| {
             tracing::error!("unable to decode DeviceRequest bytes as cbor: {}", error);
@@ -1040,12 +1065,11 @@ pub trait DeviceSession {
                     continue;
                 }
             };
-            let header = coset::HeaderBuilder::new()
-                .algorithm(signature_algorithm)
-                .build();
-
             let prepared_cose = match self.device_auth_type() {
                 DeviceAuthType::Sign1 => {
+                    let header = coset::HeaderBuilder::new()
+                        .algorithm(signature_algorithm)
+                        .build();
                     let cose_sign1_builder = CoseSign1Builder::new().protected(header);
                     let prepared_cose_sign1 = match PreparedCoseSign1::new(
                         cose_sign1_builder,
@@ -1066,6 +1090,9 @@ pub trait DeviceSession {
                     PreparedCose::Sign1(prepared_cose_sign1)
                 }
                 DeviceAuthType::Mac0 => {
+                    let header = coset::HeaderBuilder::new()
+                        .algorithm(coset::iana::Algorithm::HMAC_256_256)
+                        .build();
                     let cose_mac0_builder = CoseMac0Builder::new().protected(header);
                     let prepared_cose_mac0 = match PreparedCoseMac0::new(
                         cose_mac0_builder,

--- a/src/presentation/device.rs
+++ b/src/presentation/device.rs
@@ -402,8 +402,8 @@ impl SessionManagerEngaged {
         let sk_reader = derive_session_key(&shared_secret, &session_transcript_bytes, true)?.into();
         let sk_device =
             derive_session_key(&shared_secret, &session_transcript_bytes, false)?.into();
-        let e_mac_key: [u8; 32] = derive_e_mac_key(&shared_secret, &session_transcript_bytes)?
-            .into();
+        let e_mac_key: [u8; 32] =
+            derive_e_mac_key(&shared_secret, &session_transcript_bytes)?.into();
 
         let mut sm = SessionManager {
             documents: self.documents,

--- a/src/presentation/reader.rs
+++ b/src/presentation/reader.rs
@@ -40,8 +40,8 @@ use crate::{
         device_response::Document,
         helpers::{non_empty_vec, NonEmptyVec, Tag24},
         session::{
-            self, create_p256_ephemeral_keys, derive_session_key, get_shared_secret,
-            SessionEstablishment,
+            self, create_p256_ephemeral_keys, derive_e_mac_key, derive_session_key,
+            get_shared_secret, SessionEstablishment,
         },
         x509::{trust_anchor::TrustAnchorRegistry, x5chain::X5CHAIN_COSE_HEADER_LABEL, X5Chain},
         DeviceEngagement, DeviceResponse, SessionData, SessionTranscript180135,
@@ -62,6 +62,8 @@ pub struct SessionManager {
     device_message_counter: u32,
     sk_reader: [u8; 32],
     reader_message_counter: u32,
+    #[serde(default)]
+    e_mac_key: Option<[u8; 32]>,
     trust_anchor_registry: TrustAnchorRegistry,
     holder_le_role: Option<LeRole>,
     holder_central_client_modes: Vec<CentralClientMode>,
@@ -310,6 +312,10 @@ impl SessionManager {
         let sk_device = derive_session_key(&shared_secret, &session_transcript_bytes, false)
             .context("failed to derive device session key")?
             .into();
+        let e_mac_key: [u8; 32] =
+            derive_e_mac_key(&shared_secret, &session_transcript_bytes)
+                .context("failed to derive e_mac_key")?
+                .into();
 
         let mut session_manager = Self {
             session_transcript,
@@ -317,6 +323,7 @@ impl SessionManager {
             device_message_counter: 0,
             sk_reader,
             reader_message_counter: 0,
+            e_mac_key: Some(e_mac_key),
             trust_anchor_registry,
             holder_le_role,
             holder_central_client_modes,
@@ -471,6 +478,7 @@ impl SessionManager {
                     namespaces,
                     doc_types,
                     revocation_fetcher,
+                    self.e_mac_key,
                 )
                 .await
             }

--- a/src/presentation/reader.rs
+++ b/src/presentation/reader.rs
@@ -312,10 +312,9 @@ impl SessionManager {
         let sk_device = derive_session_key(&shared_secret, &session_transcript_bytes, false)
             .context("failed to derive device session key")?
             .into();
-        let e_mac_key: [u8; 32] =
-            derive_e_mac_key(&shared_secret, &session_transcript_bytes)
-                .context("failed to derive e_mac_key")?
-                .into();
+        let e_mac_key: [u8; 32] = derive_e_mac_key(&shared_secret, &session_transcript_bytes)
+            .context("failed to derive e_mac_key")?
+            .into();
 
         let mut session_manager = Self {
             session_transcript,

--- a/src/presentation/reader.rs
+++ b/src/presentation/reader.rs
@@ -40,8 +40,8 @@ use crate::{
         device_response::Document,
         helpers::{non_empty_vec, NonEmptyVec, Tag24},
         session::{
-            self, create_p256_ephemeral_keys, derive_e_mac_key, derive_session_key,
-            get_shared_secret, SessionEstablishment,
+            self, create_p256_ephemeral_keys, derive_session_key, get_shared_secret,
+            SessionEstablishment,
         },
         x509::{trust_anchor::TrustAnchorRegistry, x5chain::X5CHAIN_COSE_HEADER_LABEL, X5Chain},
         DeviceEngagement, DeviceResponse, SessionData, SessionTranscript180135,
@@ -62,8 +62,7 @@ pub struct SessionManager {
     device_message_counter: u32,
     sk_reader: [u8; 32],
     reader_message_counter: u32,
-    #[serde(default)]
-    e_mac_key: Option<[u8; 32]>,
+    e_reader_key_private: [u8; 32],
     trust_anchor_registry: TrustAnchorRegistry,
     holder_le_role: Option<LeRole>,
     holder_central_client_modes: Vec<CentralClientMode>,
@@ -281,6 +280,9 @@ impl SessionManager {
         let e_reader_key_public =
             Tag24::new(key_pair.1).context("failed to encode public cose key")?;
 
+        // Save private key bytes before consuming the key for ECDH
+        let e_reader_key_private_bytes: [u8; 32] = e_reader_key_private.to_bytes().into();
+
         //decode device_engagement
         let device_engagement = device_engagement_bytes.as_ref();
         let e_device_key = &device_engagement.security.1;
@@ -312,9 +314,6 @@ impl SessionManager {
         let sk_device = derive_session_key(&shared_secret, &session_transcript_bytes, false)
             .context("failed to derive device session key")?
             .into();
-        let e_mac_key: [u8; 32] = derive_e_mac_key(&shared_secret, &session_transcript_bytes)
-            .context("failed to derive e_mac_key")?
-            .into();
 
         let mut session_manager = Self {
             session_transcript,
@@ -322,7 +321,7 @@ impl SessionManager {
             device_message_counter: 0,
             sk_reader,
             reader_message_counter: 0,
-            e_mac_key: Some(e_mac_key),
+            e_reader_key_private: e_reader_key_private_bytes,
             trust_anchor_registry,
             holder_le_role,
             holder_central_client_modes,
@@ -477,7 +476,7 @@ impl SessionManager {
                     namespaces,
                     doc_types,
                     revocation_fetcher,
-                    self.e_mac_key,
+                    self.e_reader_key_private,
                 )
                 .await
             }

--- a/src/presentation/reader_utils.rs
+++ b/src/presentation/reader_utils.rs
@@ -24,8 +24,9 @@ use super::authentication::{
 /// * `namespaces` - The namespaces from the response
 /// * `doc_types` - The document types from the response
 /// * `revocation_fetcher` - Revocation fetcher for CRL checking. Use `&()` to skip revocation checks.
-/// * `e_mac_key` - The EMacKey for COSE_Mac0 device authentication. Required when the device
-///   uses MAC-based authentication; ignored for COSE_Sign1.
+/// * `e_reader_key_private` - The reader's ephemeral private key bytes, used for ECDH with the
+///   device's static authentication key (SDeviceKey) when verifying COSE_Mac0 per §9.1.3.5.
+///   Ignored when the device uses COSE_Sign1.
 #[allow(clippy::too_many_arguments)]
 pub async fn validate_response<S, R>(
     session_transcript: S,
@@ -35,7 +36,7 @@ pub async fn validate_response<S, R>(
     namespaces: BTreeMap<String, serde_json::Value>,
     doc_types: Vec<String>,
     revocation_fetcher: &R,
-    e_mac_key: Option<[u8; 32]>,
+    e_reader_key_private: [u8; 32],
 ) -> ResponseAuthenticationOutcome
 where
     S: SessionTranscript + Clone,
@@ -47,7 +48,7 @@ where
         ..Default::default()
     };
 
-    match device_authentication(&document, session_transcript.clone(), e_mac_key.as_ref()) {
+    match device_authentication(&document, session_transcript.clone(), &e_reader_key_private) {
         Ok(_) => {
             validated_response.device_authentication = AuthenticationStatus::Valid;
         }

--- a/src/presentation/reader_utils.rs
+++ b/src/presentation/reader_utils.rs
@@ -24,6 +24,8 @@ use super::authentication::{
 /// * `namespaces` - The namespaces from the response
 /// * `doc_types` - The document types from the response
 /// * `revocation_fetcher` - Revocation fetcher for CRL checking. Use `&()` to skip revocation checks.
+/// * `e_mac_key` - The EMacKey for COSE_Mac0 device authentication. Required when the device
+///   uses MAC-based authentication; ignored for COSE_Sign1.
 pub async fn validate_response<S, R>(
     session_transcript: S,
     trust_anchor_registry: TrustAnchorRegistry,
@@ -32,6 +34,7 @@ pub async fn validate_response<S, R>(
     namespaces: BTreeMap<String, serde_json::Value>,
     doc_types: Vec<String>,
     revocation_fetcher: &R,
+    e_mac_key: Option<[u8; 32]>,
 ) -> ResponseAuthenticationOutcome
 where
     S: SessionTranscript + Clone,
@@ -43,7 +46,7 @@ where
         ..Default::default()
     };
 
-    match device_authentication(&document, session_transcript.clone()) {
+    match device_authentication(&document, session_transcript.clone(), e_mac_key.as_ref()) {
         Ok(_) => {
             validated_response.device_authentication = AuthenticationStatus::Valid;
         }

--- a/src/presentation/reader_utils.rs
+++ b/src/presentation/reader_utils.rs
@@ -26,6 +26,7 @@ use super::authentication::{
 /// * `revocation_fetcher` - Revocation fetcher for CRL checking. Use `&()` to skip revocation checks.
 /// * `e_mac_key` - The EMacKey for COSE_Mac0 device authentication. Required when the device
 ///   uses MAC-based authentication; ignored for COSE_Sign1.
+#[allow(clippy::too_many_arguments)]
 pub async fn validate_response<S, R>(
     session_transcript: S,
     trust_anchor_registry: TrustAnchorRegistry,

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,8 +1,11 @@
 #![allow(dead_code)]
 use anyhow::{anyhow, Context, Result};
+use digest::Mac;
+use hmac::Hmac;
 use isomdl::cbor;
 use isomdl::definitions::device_engagement::{CentralClientMode, DeviceRetrievalMethods};
 use isomdl::definitions::device_request::{DataElements, DocType, Namespaces};
+use isomdl::definitions::device_signed::DeviceAuthType;
 use isomdl::definitions::helpers::NonEmptyMap;
 use isomdl::definitions::session::Handover;
 use isomdl::definitions::x509::trust_anchor::TrustAnchorRegistry;
@@ -11,6 +14,7 @@ use isomdl::presentation::device::{Document, Documents, RequestedItems, SessionM
 use isomdl::presentation::{
     authentication::RequestAuthenticationOutcome, device, reader, Stringify,
 };
+use sha2::Sha256;
 use signature::Signer;
 use uuid::Uuid;
 
@@ -108,6 +112,39 @@ impl Device {
         session_manager
             .submit_next_signature(signature.to_vec())
             .context("failed to submit signature")?;
+        session_manager
+            .retrieve_response()
+            .ok_or(anyhow!("cannot prepare response"))
+    }
+
+    /// Prepare response with required elements using COSE_Mac0 device authentication.
+    pub fn create_response_mac0(
+        mut session_manager: device::SessionManager,
+        requested_items: &RequestedItems,
+    ) -> Result<Vec<u8>> {
+        session_manager.set_device_auth_type(DeviceAuthType::Mac0);
+        let e_mac_key = session_manager
+            .e_mac_key()
+            .ok_or_else(|| anyhow!("e_mac_key not available"))?;
+        let hmac_key =
+            Hmac::<Sha256>::new_from_slice(e_mac_key).context("failed to create HMAC key")?;
+
+        let permitted_items = [(
+            DOC_TYPE.to_string(),
+            [(NAMESPACE.to_string(), vec![AGE_OVER_21_ELEMENT.to_string()])]
+                .into_iter()
+                .collect(),
+        )]
+        .into_iter()
+        .collect();
+        session_manager.prepare_response(requested_items, permitted_items);
+        let (_, tag_payload) = session_manager.get_next_signature_payload().unwrap();
+        let mut mac = hmac_key.clone();
+        mac.update(tag_payload);
+        let tag = mac.finalize().into_bytes().to_vec();
+        session_manager
+            .submit_next_signature(tag)
+            .context("failed to submit mac tag")?;
         session_manager
             .retrieve_response()
             .ok_or(anyhow!("cannot prepare response"))

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,8 +1,11 @@
 #![allow(dead_code)]
 use anyhow::{anyhow, Context, Result};
+use digest::Mac;
+use hmac::Hmac;
 use isomdl::cbor;
 use isomdl::definitions::device_engagement::{CentralClientMode, DeviceRetrievalMethods};
 use isomdl::definitions::device_request::{DataElements, DocType, Namespaces};
+use isomdl::definitions::device_signed::DeviceAuthType;
 use isomdl::definitions::helpers::NonEmptyMap;
 use isomdl::definitions::session::Handover;
 use isomdl::definitions::x509::trust_anchor::TrustAnchorRegistry;
@@ -12,6 +15,7 @@ use isomdl::presentation::{
     authentication::{AuthenticationStatus, RequestAuthenticationOutcome},
     device, reader, Stringify,
 };
+use sha2::Sha256;
 use signature::Signer;
 use uuid::Uuid;
 
@@ -123,8 +127,10 @@ impl Device {
         requested_items: &RequestedItems,
         signing_key: &p256::ecdsa::SigningKey,
     ) -> Result<Vec<u8>> {
-        let static_secret: p256::SecretKey = signing_key.clone().into();
-        let static_scalar: p256::NonZeroScalar = static_secret.into();
+        let static_scalar: p256::NonZeroScalar = p256::SecretKey::from(signing_key.clone()).into();
+        let e_mac_key = session_manager
+            .e_mac_key_from_static_key(&static_scalar)
+            .context("failed to derive EMacKey")?;
         let permitted_items = [(
             DOC_TYPE.to_string(),
             [(NAMESPACE.to_string(), vec![AGE_OVER_21_ELEMENT.to_string()])]
@@ -133,12 +139,22 @@ impl Device {
         )]
         .into_iter()
         .collect();
-        session_manager
-            .prepare_response_mac0(requested_items, permitted_items, &static_scalar)
-            .context("failed to prepare mac0 response")?;
+        session_manager.set_device_auth_type(DeviceAuthType::Mac0);
+        session_manager.prepare_response(requested_items, permitted_items);
+        while let Some((_, payload)) = session_manager
+            .get_next_signature_payload()
+            .map(|(id, p)| (id, p.to_vec()))
+        {
+            let mut mac =
+                Hmac::<Sha256>::new_from_slice(&e_mac_key).context("failed to create HMAC")?;
+            mac.update(&payload);
+            session_manager
+                .submit_next_signature(mac.finalize().into_bytes().to_vec())
+                .context("failed to submit MAC0 tag")?;
+        }
         session_manager
             .retrieve_response()
-            .ok_or(anyhow!("cannot prepare response"))
+            .ok_or(anyhow!("cannot retrieve response"))
     }
 
     /// Load the device signing key that matches the public key embedded in the test mDL's MSO.

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -118,16 +118,22 @@ impl Device {
     }
 
     /// Prepare response with required elements using COSE_Mac0 device authentication.
+    ///
+    /// Uses the static mdoc authentication key (SDeviceKey) for EMacKey derivation per
+    /// ISO 18013-5 §9.1.3.5.
     pub fn create_response_mac0(
         mut session_manager: device::SessionManager,
         requested_items: &RequestedItems,
+        signing_key: &p256::ecdsa::SigningKey,
     ) -> Result<Vec<u8>> {
         session_manager.set_device_auth_type(DeviceAuthType::Mac0);
+        let static_secret: p256::SecretKey = signing_key.clone().into();
+        let static_scalar: p256::NonZeroScalar = static_secret.into();
         let e_mac_key = session_manager
-            .e_mac_key()
-            .ok_or_else(|| anyhow!("e_mac_key not available"))?;
+            .compute_e_mac_key_from_static_key(&static_scalar)
+            .context("failed to derive e_mac_key from static key")?;
         let hmac_key =
-            Hmac::<Sha256>::new_from_slice(e_mac_key).context("failed to create HMAC key")?;
+            Hmac::<Sha256>::new_from_slice(&e_mac_key).context("failed to create HMAC key")?;
 
         let permitted_items = [(
             DOC_TYPE.to_string(),

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -12,7 +12,8 @@ use isomdl::definitions::x509::trust_anchor::TrustAnchorRegistry;
 use isomdl::definitions::{self, BleOptions, DeviceRetrievalMethod};
 use isomdl::presentation::device::{Document, Documents, RequestedItems, SessionManagerEngaged};
 use isomdl::presentation::{
-    authentication::RequestAuthenticationOutcome, device, reader, Stringify,
+    authentication::{AuthenticationStatus, RequestAuthenticationOutcome},
+    device, reader, Stringify,
 };
 use sha2::Sha256;
 use signature::Signer;
@@ -156,8 +157,10 @@ impl Device {
             .ok_or(anyhow!("cannot prepare response"))
     }
 
+    /// Load the device signing key that matches the public key embedded in the test mDL's MSO.
     pub fn create_signing_key() -> Result<p256::ecdsa::SigningKey> {
-        Ok(p256::SecretKey::from_sec1_pem(include_str!("data/sec1.pem"))?.into())
+        let der = base64::decode(include_str!("../test/issuance/device_key.b64").trim())?;
+        Ok(p256::SecretKey::from_sec1_der(&der)?.into())
     }
 }
 
@@ -172,6 +175,10 @@ impl Reader {
         // Use () to skip CRL checks in tests
         let validated = reader_sm.handle_response(&response, &()).await;
         println!("Validated Response: {validated:?}");
+        // These tests verify the device-reader protocol. Certificate chain validation
+        // (issuer_authentication) requires a full MDL cert setup and is tested separately
+        // in src/definitions/x509/.
+        assert_eq!(validated.device_authentication, AuthenticationStatus::Valid);
         Ok(())
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,11 +1,8 @@
 #![allow(dead_code)]
 use anyhow::{anyhow, Context, Result};
-use digest::Mac;
-use hmac::Hmac;
 use isomdl::cbor;
 use isomdl::definitions::device_engagement::{CentralClientMode, DeviceRetrievalMethods};
 use isomdl::definitions::device_request::{DataElements, DocType, Namespaces};
-use isomdl::definitions::device_signed::DeviceAuthType;
 use isomdl::definitions::helpers::NonEmptyMap;
 use isomdl::definitions::session::Handover;
 use isomdl::definitions::x509::trust_anchor::TrustAnchorRegistry;
@@ -15,7 +12,6 @@ use isomdl::presentation::{
     authentication::{AuthenticationStatus, RequestAuthenticationOutcome},
     device, reader, Stringify,
 };
-use sha2::Sha256;
 use signature::Signer;
 use uuid::Uuid;
 
@@ -127,15 +123,8 @@ impl Device {
         requested_items: &RequestedItems,
         signing_key: &p256::ecdsa::SigningKey,
     ) -> Result<Vec<u8>> {
-        session_manager.set_device_auth_type(DeviceAuthType::Mac0);
         let static_secret: p256::SecretKey = signing_key.clone().into();
         let static_scalar: p256::NonZeroScalar = static_secret.into();
-        let e_mac_key = session_manager
-            .compute_e_mac_key_from_static_key(&static_scalar)
-            .context("failed to derive e_mac_key from static key")?;
-        let hmac_key =
-            Hmac::<Sha256>::new_from_slice(&e_mac_key).context("failed to create HMAC key")?;
-
         let permitted_items = [(
             DOC_TYPE.to_string(),
             [(NAMESPACE.to_string(), vec![AGE_OVER_21_ELEMENT.to_string()])]
@@ -144,14 +133,9 @@ impl Device {
         )]
         .into_iter()
         .collect();
-        session_manager.prepare_response(requested_items, permitted_items);
-        let (_, tag_payload) = session_manager.get_next_signature_payload().unwrap();
-        let mut mac = hmac_key.clone();
-        mac.update(tag_payload);
-        let tag = mac.finalize().into_bytes().to_vec();
         session_manager
-            .submit_next_signature(tag)
-            .context("failed to submit mac tag")?;
+            .prepare_response_mac0(requested_items, permitted_items, &static_scalar)
+            .context("failed to prepare mac0 response")?;
         session_manager
             .retrieve_response()
             .ok_or(anyhow!("cannot prepare response"))

--- a/tests/simulated_device_and_reader.rs
+++ b/tests/simulated_device_and_reader.rs
@@ -4,10 +4,7 @@ use crate::common::{Device, Reader};
 
 #[test_log::test(tokio::test)]
 pub async fn simulated_device_and_reader_interaction() {
-    let key: p256::ecdsa::SigningKey =
-        p256::SecretKey::from_sec1_pem(include_str!("data/sec1.pem"))
-            .unwrap()
-            .into();
+    let key = Device::create_signing_key().unwrap();
 
     // Device initialization and engagement
     let engaged_state = Device::initialise_session().unwrap();

--- a/tests/simulated_device_and_reader.rs
+++ b/tests/simulated_device_and_reader.rs
@@ -35,3 +35,31 @@ pub async fn simulated_device_and_reader_interaction() {
         .await
         .unwrap();
 }
+
+#[test_log::test(tokio::test)]
+pub async fn simulated_device_and_reader_interaction_mac0() {
+    // Device initialization and engagement
+    let engaged_state = Device::initialise_session().unwrap();
+
+    // Reader processing QR and requesting the necessary fields
+    let (mut reader_session_manager, request) =
+        Device::establish_reader_session(engaged_state.qr_handover().unwrap()).unwrap();
+
+    // Device accepting request
+    let (device_session_manager, validated_request) =
+        Device::handle_request(engaged_state, request, Default::default())
+            .await
+            .unwrap();
+
+    // Prepare response with required elements using COSE_Mac0
+    let response = Device::create_response_mac0(
+        device_session_manager,
+        &validated_request.items_request,
+    )
+    .unwrap();
+
+    // Reader Processing mDL data
+    Reader::reader_handle_device_response(&mut reader_session_manager, response)
+        .await
+        .unwrap();
+}

--- a/tests/simulated_device_and_reader.rs
+++ b/tests/simulated_device_and_reader.rs
@@ -52,11 +52,9 @@ pub async fn simulated_device_and_reader_interaction_mac0() {
             .unwrap();
 
     // Prepare response with required elements using COSE_Mac0
-    let response = Device::create_response_mac0(
-        device_session_manager,
-        &validated_request.items_request,
-    )
-    .unwrap();
+    let response =
+        Device::create_response_mac0(device_session_manager, &validated_request.items_request)
+            .unwrap();
 
     // Reader Processing mDL data
     Reader::reader_handle_device_response(&mut reader_session_manager, response)

--- a/tests/simulated_device_and_reader.rs
+++ b/tests/simulated_device_and_reader.rs
@@ -52,9 +52,13 @@ pub async fn simulated_device_and_reader_interaction_mac0() {
             .unwrap();
 
     // Prepare response with required elements using COSE_Mac0
-    let response =
-        Device::create_response_mac0(device_session_manager, &validated_request.items_request)
-            .unwrap();
+    let signing_key = Device::create_signing_key().unwrap();
+    let response = Device::create_response_mac0(
+        device_session_manager,
+        &validated_request.items_request,
+        &signing_key,
+    )
+    .unwrap();
 
     // Reader Processing mDL data
     Reader::reader_handle_device_response(&mut reader_session_manager, response)


### PR DESCRIPTION
This pull request adds support for HMAC-based device authentication (COSE_Mac0) in addition to the existing ECDSA-based authentication (COSE_Sign1), following ISO 18013-5 section 9.1.1.5. The main changes include implementing EMacKey derivation, updating authentication flows to support both signature and MAC-based methods, and passing the EMacKey through the session and validation logic.

**Support for HMAC-based device authentication:**

* Added a new function `derive_e_mac_key` in `session.rs` to derive the EMacKey from the shared secret and session transcript, as specified by ISO 18013-5.
* Updated the `device_authentication` function in `mdoc.rs` to support both ECDSA signature (`COSE_Sign1`) and HMAC-based MAC (`COSE_Mac0`) device authentication. The function now accepts an optional `e_mac_key` parameter and verifies the MAC using HMAC-SHA256 when appropriate. [[1]](diffhunk://#diff-6cfcd674404f75632ea66530a3a1e1e99c670805e4c8beb8ef99c3099eac6772L56-R64) [[2]](diffhunk://#diff-6cfcd674404f75632ea66530a3a1e1e99c670805e4c8beb8ef99c3099eac6772L95-R108) [[3]](diffhunk://#diff-6cfcd674404f75632ea66530a3a1e1e99c670805e4c8beb8ef99c3099eac6772R160-R180)

**Session management and key propagation:**

* Modified `SessionManager` in `reader.rs` to derive, store, and propagate the EMacKey as part of session establishment and pass it to downstream authentication/validation functions. [[1]](diffhunk://#diff-2d91d60befe54a88ca7e059fb9ef37756b003b7771e2e529850820bfe81203e6R65-R66) [[2]](diffhunk://#diff-2d91d60befe54a88ca7e059fb9ef37756b003b7771e2e529850820bfe81203e6R315-R326) [[3]](diffhunk://#diff-2d91d60befe54a88ca7e059fb9ef37756b003b7771e2e529850820bfe81203e6R481)

**Validation and API changes:**

* Updated the `validate_response` function in `reader_utils.rs` to accept and forward the optional EMacKey, ensuring MAC-based authentication is supported during response validation. [[1]](diffhunk://#diff-600bb877c3b1dc030376d4399b8a67c4dc6f0ec3168e2b8b11b9ed5fdaa36d85R27-R28) [[2]](diffhunk://#diff-600bb877c3b1dc030376d4399b8a67c4dc6f0ec3168e2b8b11b9ed5fdaa36d85R37) [[3]](diffhunk://#diff-600bb877c3b1dc030376d4399b8a67c4dc6f0ec3168e2b8b11b9ed5fdaa36d85L46-R49)

These changes enable the system to authenticate devices using either ECDSA signatures or HMAC-based MACs, improving compatibility with the ISO 18013-5 standard and supporting a wider range of device authentication scenarios.