### PR TITLE
Add support for negotiated NFC handover

### DIFF
--- a/src/definitions/device_engagement/nfc/apdu_handover.rs
+++ b/src/definitions/device_engagement/nfc/apdu_handover.rs
@@ -102,15 +102,9 @@ pub struct ApduHandoverDriver {
 impl ApduHandoverDriver {
     /// Create a new APDU handover driver.
     ///
-    /// * `negotiated`: true -> use negotiated handover (not implemented yet), false -> use static handover.
+    /// * `negotiated`: true -> use negotiated handover (TNEP), false -> use static handover.
     /// * `strict`: require selecting the MDOC AID before responding to NDEF reads. If strict is false, we will always return NDEF messages.
     pub fn new(negotiated: bool, strict: bool) -> Result<Self, HandoverError> {
-        if negotiated {
-            return Err(anyhow::anyhow!(
-                "Negotiated handover is not implemented yet. Please use static handover."
-            )
-            .into());
-        }
         Ok(Self {
             strict,
             state: ndef_handover::HandoverState::Init,
@@ -193,7 +187,7 @@ impl ApduHandoverDriver {
                     }
 
                     let handover_resp = if self.negotiated {
-                        todo!("Implement negotiated handover");
+                        ndef_handover::get_negotiated_tp_ndef_response()
                     } else {
                         ndef_handover::get_static_handover_ndef_response(self.static_ble.clone())
                     };
@@ -250,13 +244,36 @@ impl ApduHandoverDriver {
                     payload: data,
                 }
             }
-            apdu::Apdu::UpdateBinary { offset, data } => {
+            apdu::Apdu::UpdateBinary { offset: _, data } => {
                 if !self.negotiated {
                     return apdu::ResponseCode::ConditionsNotSatisfied.into();
                 }
-                _ = offset;
-                _ = data;
-                todo!("Implement negotiated handover");
+                let handover_resp = match &self.state {
+                    ndef_handover::HandoverState::WaitingForServiceSelect => {
+                        ndef_handover::handle_ts_write(data)
+                    }
+                    ndef_handover::HandoverState::WaitingForHandoverRequest => {
+                        ndef_handover::handle_hr_write(data, self.static_ble.clone())
+                    }
+                    _ => {
+                        tracing::error!("UpdateBinary in unexpected state: {:?}", self.state);
+                        self.reset();
+                        return apdu::ResponseCode::ConditionsNotSatisfied.into();
+                    }
+                };
+                match handover_resp {
+                    Ok(ndef_handover::HandoverResponse { new_state, ndef }) => {
+                        self.state = new_state;
+                        self.ndef_send =
+                            Some([&u16::to_be_bytes(ndef.len() as u16) as &[u8], &ndef].concat());
+                        apdu::ResponseCode::Ok.into()
+                    }
+                    Err(e) => {
+                        tracing::error!("NDEF handover error during UpdateBinary: {e:?}");
+                        self.reset();
+                        apdu::ResponseCode::Unspecified.into()
+                    }
+                }
             }
         }
     }
@@ -302,5 +319,34 @@ mod test {
             .process_rapdu(&rapdu)
             .expect("failed to process rpdu");
         assert!(matches!(res, ReaderApduProgress::Done(_)));
+    }
+
+    #[test]
+    fn roundtrip_negotiated_handover() {
+        let mut holder = ApduHandoverDriver::new(true, false)
+            .expect("failed to build holder apdu handover driver");
+        let (mut reader, mut apdu) = ReaderApduHandoverDriver::new();
+        let mut iterations = 0;
+        loop {
+            assert!(
+                iterations < 20,
+                "negotiated handover did not complete in 20 iterations"
+            );
+            iterations += 1;
+            let rapdu = holder.process_apdu(&apdu);
+            match reader
+                .process_rapdu(&rapdu)
+                .expect("failed to process rapdu")
+            {
+                ReaderApduProgress::InProgress(next_apdu) => apdu = next_apdu,
+                ReaderApduProgress::Done(_) => {
+                    assert!(
+                        holder.get_carrier_info().is_some(),
+                        "holder carrier_info should be available after negotiated handover"
+                    );
+                    break;
+                }
+            }
+        }
     }
 }

--- a/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
@@ -4,11 +4,15 @@ use crate::definitions::device_engagement::nfc::{
         select::{ControlInfo, Occurrence},
         Apdu, FileId,
     },
-    ndef_handover_reader::{ReaderHandoverState, ReaderNegotiatedCarrierInfo},
+    ndef_handover_reader::{
+        detect_tp_service, generate_hr_ndef, generate_ts_ndef, parse_te_ndef, ReaderHandoverState,
+        ReaderNegotiatedCarrierInfo, TNEP_HANDOVER_SERVICE_URI,
+    },
     util::KnownOrRaw,
     APDU_AID_NDEF_APPLICATION, CC_FILE_TEMPLATE,
 };
 
+use crate::definitions::helpers::ByteStr;
 use thiserror::Error;
 use tracing::debug;
 
@@ -40,6 +44,11 @@ pub struct ReaderApduHandoverDriver {
 pub enum ReaderApduProgress {
     InProgress(Vec<u8>),
     Done(Box<ReaderNegotiatedCarrierInfo>),
+}
+
+fn with_ndef_length_prefix(ndef: &[u8]) -> Vec<u8> {
+    let len_bytes = (ndef.len() as u16).to_be_bytes();
+    [len_bytes.as_slice(), ndef].concat()
 }
 
 impl ReaderApduHandoverDriver {
@@ -143,10 +152,23 @@ impl ReaderApduHandoverDriver {
                 let data = [data, ndef_recv.as_slice()].concat();
                 let offset = data.len();
                 if &offset == total_length {
-                    let carrier_info = ReaderNegotiatedCarrierInfo::parse_ndef_message(&data)
-                        .map_err(ReaderApduError::NdefMessageError)?;
-                    self.state = ReaderHandoverState::Done;
-                    Ok(ReaderApduProgress::Done(Box::new(carrier_info)))
+                    if detect_tp_service(&data).is_some() {
+                        // Negotiated handover: write Ts (Service Select)
+                        let ts_ndef = generate_ts_ndef(TNEP_HANDOVER_SERVICE_URI)
+                            .map_err(ReaderApduError::NdefMessageError)?;
+                        let ts_apdu = Apdu::UpdateBinary {
+                            offset: 0,
+                            data: &with_ndef_length_prefix(&ts_ndef),
+                        };
+                        self.state = ReaderHandoverState::WaitingForTsWriteResponse;
+                        Ok(ReaderApduProgress::InProgress(ts_apdu.to_bytes()))
+                    } else {
+                        // Static handover
+                        let carrier_info = ReaderNegotiatedCarrierInfo::parse_ndef_message(&data)
+                            .map_err(ReaderApduError::NdefMessageError)?;
+                        self.state = ReaderHandoverState::Done;
+                        Ok(ReaderApduProgress::Done(Box::new(carrier_info)))
+                    }
                 } else {
                     let chunk_len = if total_length - offset <= self.max_buffer_size {
                         total_length - offset
@@ -161,6 +183,130 @@ impl ReaderApduHandoverDriver {
                         data,
                     };
                     Ok(ReaderApduProgress::InProgress(apdu.to_bytes()))
+                }
+            }
+            // Negotiated handover states
+            ReaderHandoverState::WaitingForTsWriteResponse => {
+                // Ts was written (0x9000 received); read the Te NDEF length
+                self.state = ReaderHandoverState::WaitingForTeLength;
+                Ok(ReaderApduProgress::InProgress(
+                    Apdu::ReadBinary { slice: 0..2 }.to_bytes(),
+                ))
+            }
+            ReaderHandoverState::WaitingForTeLength => {
+                let te_len_bytes = rapdu.payload;
+                if te_len_bytes.len() != 2 {
+                    return Err(ReaderApduError::InvalidApduResponse(
+                        "Expected 2-byte Te NDEF length".into(),
+                    ));
+                }
+                let te_len = u16::from_be_bytes(*te_len_bytes.first_chunk::<2>().unwrap()) as usize;
+                let chunk_len = te_len.min(self.max_buffer_size);
+                self.state = ReaderHandoverState::WaitingForTeData {
+                    total_length: te_len,
+                    data: vec![],
+                };
+                Ok(ReaderApduProgress::InProgress(
+                    Apdu::ReadBinary {
+                        slice: 2..2 + chunk_len,
+                    }
+                    .to_bytes(),
+                ))
+            }
+            ReaderHandoverState::WaitingForTeData { total_length, data } => {
+                let data = [data, rapdu.payload.as_slice()].concat();
+                let offset = data.len();
+                if &offset == total_length {
+                    // Te received; check TNEP status then write Hr
+                    parse_te_ndef(&data).map_err(ReaderApduError::NdefMessageError)?;
+                    let (hr_ndef, hr_uuid) =
+                        generate_hr_ndef().map_err(ReaderApduError::NdefMessageError)?;
+                    let hr_bytes = hr_ndef.clone();
+                    let hr_apdu = Apdu::UpdateBinary {
+                        offset: 0,
+                        data: &with_ndef_length_prefix(&hr_ndef),
+                    };
+                    self.state =
+                        ReaderHandoverState::WaitingForHrWriteResponse { hr_bytes, hr_uuid };
+                    Ok(ReaderApduProgress::InProgress(hr_apdu.to_bytes()))
+                } else {
+                    let chunk_len = (total_length - offset).min(self.max_buffer_size);
+                    self.state = ReaderHandoverState::WaitingForTeData {
+                        total_length: *total_length,
+                        data,
+                    };
+                    Ok(ReaderApduProgress::InProgress(
+                        Apdu::ReadBinary {
+                            slice: 2 + offset..2 + offset + chunk_len,
+                        }
+                        .to_bytes(),
+                    ))
+                }
+            }
+            ReaderHandoverState::WaitingForHrWriteResponse { hr_bytes, hr_uuid } => {
+                // Hr was written (0x9000 received); read the Hs NDEF length
+                let hr_bytes = hr_bytes.clone();
+                let hr_uuid = *hr_uuid;
+                self.state = ReaderHandoverState::WaitingForHsLength { hr_bytes, hr_uuid };
+                Ok(ReaderApduProgress::InProgress(
+                    Apdu::ReadBinary { slice: 0..2 }.to_bytes(),
+                ))
+            }
+            ReaderHandoverState::WaitingForHsLength { hr_bytes, hr_uuid } => {
+                let hs_len_bytes = rapdu.payload;
+                if hs_len_bytes.len() != 2 {
+                    return Err(ReaderApduError::InvalidApduResponse(
+                        "Expected 2-byte Hs NDEF length".into(),
+                    ));
+                }
+                let hs_len = u16::from_be_bytes(*hs_len_bytes.first_chunk::<2>().unwrap()) as usize;
+                let chunk_len = hs_len.min(self.max_buffer_size);
+                let hr_bytes = hr_bytes.clone();
+                let hr_uuid = *hr_uuid;
+                self.state = ReaderHandoverState::WaitingForHsData {
+                    total_length: hs_len,
+                    data: vec![],
+                    hr_bytes,
+                    hr_uuid,
+                };
+                Ok(ReaderApduProgress::InProgress(
+                    Apdu::ReadBinary {
+                        slice: 2..2 + chunk_len,
+                    }
+                    .to_bytes(),
+                ))
+            }
+            ReaderHandoverState::WaitingForHsData {
+                total_length,
+                data,
+                hr_bytes,
+                hr_uuid,
+            } => {
+                let data = [data, rapdu.payload.as_slice()].concat();
+                let offset = data.len();
+                if &offset == total_length {
+                    let mut carrier_info =
+                        ReaderNegotiatedCarrierInfo::parse_hs_ndef_message(&data, *hr_uuid)
+                            .map_err(ReaderApduError::NdefMessageError)?;
+                    carrier_info.hr_message = Some(ByteStr::from(hr_bytes.clone()));
+                    self.state = ReaderHandoverState::Done;
+                    Ok(ReaderApduProgress::Done(Box::new(carrier_info)))
+                } else {
+                    let chunk_len = (total_length - offset).min(self.max_buffer_size);
+                    let hr_bytes = hr_bytes.clone();
+                    let hr_uuid = *hr_uuid;
+                    self.state = ReaderHandoverState::WaitingForHsData {
+                        total_length: *total_length,
+                        data,
+                        hr_bytes,
+                        hr_uuid,
+                    };
+                    Ok(ReaderApduProgress::InProgress(
+                        Apdu::ReadBinary {
+                            slice: 2 + offset..2 + offset + chunk_len,
+                        }
+                        .to_bytes(),
+                    ))
                 }
             }
             ReaderHandoverState::Done => Err(ReaderApduError::Done),
@@ -216,8 +362,10 @@ mod test {
         assert!(matches!(res, ReaderApduProgress::Done(_)));
     }
 
-    #[test]
-    /// Transcript from a manual test
+    /// Full round-trip transcript from a manual test session with multipaz on Android.
+    /// multipaz's Hs BLE OOB record contains only the LE Role (no UUID); the reader's Hr UUID
+    /// is used as the fallback for the BLE connection.
+    #[test_log::test]
     fn multipaz_negotiated() {
         let mut driver = ReaderApduHandoverDriver::new().0;
         driver
@@ -238,15 +386,90 @@ mod test {
         driver
             .process_rapdu(&[0x00, 0x1F, 0x90, 0x00])
             .expect("failed to process rapdu 5");
-        let res = driver.process_rapdu(&[
-            0xD1, 0x02, 0x1A, 0x54, 0x70, 0x10, 0x13, 0x75, 0x72, 0x6E, 0x3A, 0x6E, 0x66, 0x63,
-            0x3A, 0x73, 0x6E, 0x3A, 0x68, 0x61, 0x6E, 0x64, 0x6F, 0x76, 0x65, 0x72, 0x00, 0x00,
-            0x0F, 0xFF, 0xFF, 0x90, 0x00,
-        ]);
-        assert_eq!(
-            res.unwrap_err().to_string(),
-            "NDEF decoding failure: negotiated handover not supported"
-        );
+        // Device returns Tp (TNEP Service Parameter) record
+        let res = driver
+            .process_rapdu(&[
+                0xD1, 0x02, 0x1A, 0x54, 0x70, 0x10, 0x13, 0x75, 0x72, 0x6E, 0x3A, 0x6E, 0x66, 0x63,
+                0x3A, 0x73, 0x6E, 0x3A, 0x68, 0x61, 0x6E, 0x64, 0x6F, 0x76, 0x65, 0x72, 0x00, 0x00,
+                0x0F, 0xFF, 0xFF, 0x90, 0x00,
+            ])
+            .expect("failed to process rapdu 6");
+        // Driver should respond with UPDATE BINARY writing Ts (Service Select)
+        let expected_ts_apdu =
+            hex::decode("00d600001b0019d1021454731375726e3a6e66633a736e3a68616e646f766572")
+                .unwrap();
+        match res {
+            ReaderApduProgress::InProgress(bytes) => assert_eq!(bytes, expected_ts_apdu),
+            _ => panic!("expected InProgress with Ts UPDATE BINARY, got {res:?}"),
+        }
+        // Ts write acknowledged → READ BINARY 0..2 (Te length)
+        let res = driver
+            .process_rapdu(&[0x90, 0x00])
+            .expect("failed to process rapdu 7");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x00, 0x02]);
+            }
+            _ => panic!("expected READ BINARY for Te length, got {res:?}"),
+        }
+        // Te NDEF length = 6 bytes → READ BINARY 2..8 (Te data)
+        let res = driver
+            .process_rapdu(&[0x00, 0x06, 0x90, 0x00])
+            .expect("failed to process rapdu 8");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x02, 0x06]);
+            }
+            _ => panic!("expected READ BINARY for Te data, got {res:?}"),
+        }
+        // Te data (TNEP status 0x00 = success) → UPDATE BINARY Hr (171 bytes)
+        let res = driver
+            .process_rapdu(&[0xD1, 0x02, 0x01, 0x54, 0x65, 0x00, 0x90, 0x00])
+            .expect("failed to process rapdu 9");
+        let ReaderApduProgress::InProgress(hr_apdu) = res else {
+            panic!("expected InProgress with Hr UPDATE BINARY, got {res:?}");
+        };
+        assert_eq!(hr_apdu.len(), 171);
+        // Hr write acknowledged → READ BINARY 0..2 (Hs length)
+        let res = driver
+            .process_rapdu(&[0x90, 0x00])
+            .expect("failed to process rapdu 10");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x00, 0x02]);
+            }
+            _ => panic!("expected READ BINARY for Hs length, got {res:?}"),
+        }
+        // Hs NDEF length = 186 bytes → READ BINARY 2..188 (Hs data)
+        let res = driver
+            .process_rapdu(&[0x00, 0xBA, 0x90, 0x00])
+            .expect("failed to process rapdu 11");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x02, 0xBA]);
+            }
+            _ => panic!("expected READ BINARY for Hs data, got {res:?}"),
+        }
+        // Hs NDEF (186 bytes from multipaz — BLE OOB has no UUID; Hr UUID used as fallback)
+        let res = driver
+            .process_rapdu(&[
+                0x91, 0x02, 0x0F, 0x48, 0x73, 0x15, 0xD1, 0x02, 0x09, 0x61, 0x63, 0x01, 0x01, 0x30,
+                0x01, 0x04, 0x6D, 0x64, 0x6F, 0x63, 0x1C, 0x1E, 0x58, 0x04, 0x69, 0x73, 0x6F, 0x2E,
+                0x6F, 0x72, 0x67, 0x3A, 0x31, 0x38, 0x30, 0x31, 0x33, 0x3A, 0x64, 0x65, 0x76, 0x69,
+                0x63, 0x65, 0x65, 0x6E, 0x67, 0x61, 0x67, 0x65, 0x6D, 0x65, 0x6E, 0x74, 0x6D, 0x64,
+                0x6F, 0x63, 0xA2, 0x00, 0x63, 0x31, 0x2E, 0x30, 0x01, 0x82, 0x01, 0xD8, 0x18, 0x58,
+                0x4B, 0xA4, 0x01, 0x02, 0x20, 0x01, 0x21, 0x58, 0x20, 0x5E, 0xB2, 0x16, 0xAC, 0x43,
+                0x77, 0xD2, 0x9E, 0xA6, 0x1C, 0xF1, 0x3E, 0x71, 0x24, 0x7A, 0x45, 0xC2, 0xE5, 0x60,
+                0xF0, 0x1E, 0xCC, 0x66, 0x22, 0x1E, 0x2D, 0xB7, 0x1C, 0x02, 0xD9, 0x75, 0x05, 0x22,
+                0x58, 0x20, 0x07, 0x29, 0x3E, 0x94, 0x76, 0x00, 0xB0, 0x34, 0x39, 0x8B, 0xBA, 0xE0,
+                0x12, 0xF3, 0xF9, 0xDF, 0x49, 0x69, 0x2B, 0x73, 0x77, 0xE8, 0x8A, 0xDF, 0x46, 0x53,
+                0x24, 0x78, 0xB2, 0x97, 0xE8, 0x64, 0x5A, 0x20, 0x03, 0x01, 0x61, 0x70, 0x70, 0x6C,
+                0x69, 0x63, 0x61, 0x74, 0x69, 0x6F, 0x6E, 0x2F, 0x76, 0x6E, 0x64, 0x2E, 0x62, 0x6C,
+                0x75, 0x65, 0x74, 0x6F, 0x6F, 0x74, 0x68, 0x2E, 0x6C, 0x65, 0x2E, 0x6F, 0x6F, 0x62,
+                0x30, 0x02, 0x1C, 0x01, 0x90, 0x00,
+            ])
+            .expect("failed to process rapdu 12");
+        assert!(matches!(res, ReaderApduProgress::Done(_)));
     }
 
     #[test_log::test]
@@ -291,6 +514,146 @@ mod test {
                 0x90, 0x00,
             ])
             .expect("failed to process rapdu 6");
+        assert!(matches!(res, ReaderApduProgress::Done(_)));
+    }
+
+    /// Full round-trip transcript from a manual test session with Google Wallet on Android.
+    #[test_log::test]
+    fn google_wallet() {
+        let mut driver = ReaderApduHandoverDriver::new().0;
+        driver
+            .process_rapdu(&[0x90, 0x00])
+            .expect("failed to process rapdu 1");
+        driver
+            .process_rapdu(&[0x90, 0x00])
+            .expect("failed to process rapdu 2");
+        driver
+            .process_rapdu(&[
+                0x00, 0x0F, 0x20, 0x7F, 0xFF, 0x7F, 0xFF, 0x04, 0x06, 0xE1, 0x04, 0x7F, 0xFF, 0x00,
+                0x00, 0x90, 0x00,
+            ])
+            .expect("failed to process rapdu 3");
+        driver
+            .process_rapdu(&[0x90, 0x00])
+            .expect("failed to process rapdu 4");
+        driver
+            .process_rapdu(&[0x00, 0x1F, 0x90, 0x00])
+            .expect("failed to process rapdu 5");
+        // Device returns Tp (TNEP Service Parameter) record
+        let res = driver
+            .process_rapdu(&[
+                0xD1, 0x02, 0x1A, 0x54, 0x70, 0x10, 0x13, 0x75, 0x72, 0x6E, 0x3A, 0x6E, 0x66, 0x63,
+                0x3A, 0x73, 0x6E, 0x3A, 0x68, 0x61, 0x6E, 0x64, 0x6F, 0x76, 0x65, 0x72, 0x00, 0x10,
+                0x0F, 0xFF, 0xFF, 0x90, 0x00,
+            ])
+            .expect("failed to process rapdu 6");
+        // Driver should respond with UPDATE BINARY writing Ts (Service Select)
+        let expected_ts_apdu =
+            hex::decode("00d600001b0019d1021454731375726e3a6e66633a736e3a68616e646f766572")
+                .unwrap();
+        match res {
+            ReaderApduProgress::InProgress(bytes) => assert_eq!(bytes, expected_ts_apdu),
+            _ => panic!("expected InProgress with Ts UPDATE BINARY, got {res:?}"),
+        }
+        // Ts write acknowledged → READ BINARY 0..2 (Te length)
+        let res = driver
+            .process_rapdu(&[0x90, 0x00])
+            .expect("failed to process rapdu 7");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x00, 0x02]);
+            }
+            _ => panic!("expected READ BINARY for Te length, got {res:?}"),
+        }
+        // Te NDEF length = 6 bytes → READ BINARY 2..8 (Te data)
+        let res = driver
+            .process_rapdu(&[0x00, 0x06, 0x90, 0x00])
+            .expect("failed to process rapdu 8");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x02, 0x06]);
+            }
+            _ => panic!("expected READ BINARY for Te data, got {res:?}"),
+        }
+        // Te data (TNEP status 0x00 = success) → UPDATE BINARY Hr
+        let res = driver
+            .process_rapdu(&[0xD1, 0x02, 0x01, 0x54, 0x65, 0x00, 0x90, 0x00])
+            .expect("failed to process rapdu 9");
+        let ReaderApduProgress::InProgress(hr_apdu) = res else {
+            panic!("expected InProgress with Hr UPDATE BINARY, got {res:?}");
+        };
+        // Hr APDU: UPDATE BINARY header (5) + 2-byte NDEF length + 164-byte NDEF = 171 bytes total.
+        // NDEF: Hr(26) + ReaderEngagement(50) + BLE OOB(58) + NFC Config(30) = 164 bytes.
+        // The NDEF contains a random UUID in the BLE OOB record; verify the deterministic portions.
+        assert_eq!(hr_apdu.len(), 171);
+        assert_eq!(&hr_apdu[..5], &[0x00, 0xD6, 0x00, 0x00, 0xA6]);
+        // bytes 5..125: NDEF length prefix + Hr record + ReaderEngagement record + BLE OOB through UUID prefix
+        #[rustfmt::skip]
+        assert_eq!(&hr_apdu[5..125], &[
+            0x00, 0xA4, // NDEF length (164)
+            // Hr record
+            0x91, 0x02, 0x15, 0x48, 0x72, 0x15, 0x91, 0x02, 0x04, 0x61, 0x63, 0x01, 0x01, 0x30,
+            0x00, 0x51, 0x02, 0x06, 0x61, 0x63, 0x01, 0x03, 0x6E, 0x66, 0x63, 0x00,
+            // ReaderEngagement record
+            0x1C, 0x1E, 0x06, 0x0A, 0x69, 0x73, 0x6F, 0x2E, 0x6F, 0x72, 0x67, 0x3A, 0x31, 0x38,
+            0x30, 0x31, 0x33, 0x3A, 0x72, 0x65, 0x61, 0x64, 0x65, 0x72, 0x65, 0x6E, 0x67, 0x61,
+            0x67, 0x65, 0x6D, 0x65, 0x6E, 0x74, 0x6D, 0x64, 0x6F, 0x63, 0x72, 0x65, 0x61, 0x64,
+            0x65, 0x72, 0xA1, 0x00, 0x63, 0x31, 0x2E, 0x30,
+            // BLE OOB record: flags, type_len, payload_len, id_len, type, id, payload prefix (before UUID)
+            0x1A, 0x20, 0x15, 0x01, 0x61, 0x70, 0x70, 0x6C, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6F,
+            0x6E, 0x2F, 0x76, 0x6E, 0x64, 0x2E, 0x62, 0x6C, 0x75, 0x65, 0x74, 0x6F, 0x6F, 0x74,
+            0x68, 0x2E, 0x6C, 0x65, 0x2E, 0x6F, 0x6F, 0x62, 0x30, 0x02, 0x1C, 0x03, 0x11, 0x07,
+        ]);
+        // bytes 125..141: random UUID (16 bytes) — not checked
+        // bytes 141..171: NFC Carrier Config record (30 bytes, 6-byte payload per interop workaround)
+        assert_eq!(
+            &hr_apdu[141..],
+            &[
+                0x5C, 0x11, 0x06, 0x03, 0x69, 0x73, 0x6F, 0x2E, 0x6F, 0x72, 0x67, 0x3A, 0x31, 0x38,
+                0x30, 0x31, 0x33, 0x3A, 0x6E, 0x66, 0x63, 0x6E, 0x66, 0x63, 0x01, 0x01, 0xFF, 0x02,
+                0xFF, 0xFF,
+            ]
+        );
+        // Hr write acknowledged → READ BINARY 0..2 (Hs length)
+        let res = driver
+            .process_rapdu(&[0x90, 0x00])
+            .expect("failed to process rapdu 10");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x00, 0x02]);
+            }
+            _ => panic!("expected READ BINARY for Hs length, got {res:?}"),
+        }
+        // Hs NDEF length = 204 bytes → READ BINARY 2..206 (Hs data)
+        let res = driver
+            .process_rapdu(&[0x00, 0xCC, 0x90, 0x00])
+            .expect("failed to process rapdu 11");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x02, 0xCC]);
+            }
+            _ => panic!("expected READ BINARY for Hs data, got {res:?}"),
+        }
+        // Hs NDEF data (204 bytes from Google Wallet) → Done
+        let res = driver
+            .process_rapdu(&[
+                0x91, 0x02, 0x0F, 0x48, 0x73, 0x15, 0xD1, 0x02, 0x09, 0x61, 0x63, 0x01, 0x01, 0x30,
+                0x01, 0x04, 0x6D, 0x64, 0x6F, 0x63, 0x1C, 0x1E, 0x58, 0x04, 0x69, 0x73, 0x6F, 0x2E,
+                0x6F, 0x72, 0x67, 0x3A, 0x31, 0x38, 0x30, 0x31, 0x33, 0x3A, 0x64, 0x65, 0x76, 0x69,
+                0x63, 0x65, 0x65, 0x6E, 0x67, 0x61, 0x67, 0x65, 0x6D, 0x65, 0x6E, 0x74, 0x6D, 0x64,
+                0x6F, 0x63, 0xA2, 0x00, 0x63, 0x31, 0x2E, 0x30, 0x01, 0x82, 0x01, 0xD8, 0x18, 0x58,
+                0x4B, 0xA4, 0x01, 0x02, 0x20, 0x01, 0x21, 0x58, 0x20, 0xE8, 0x37, 0xB6, 0x08, 0x59,
+                0x1A, 0xC6, 0x39, 0x91, 0xA9, 0xA2, 0x14, 0xED, 0x50, 0xC9, 0xA1, 0x90, 0x3F, 0x26,
+                0xCA, 0x19, 0xF1, 0x6A, 0xFD, 0x28, 0xF7, 0x78, 0xD4, 0x8E, 0x3C, 0x94, 0x6C, 0x22,
+                0x58, 0x20, 0xB3, 0x8C, 0xA0, 0xDA, 0xF7, 0xD7, 0x96, 0xDF, 0x4E, 0x5B, 0xCA, 0x0D,
+                0xA3, 0x70, 0x50, 0xD5, 0x41, 0x21, 0xBA, 0xBA, 0xED, 0xFA, 0x39, 0xA7, 0x96, 0x27,
+                0x6B, 0x05, 0x3C, 0x03, 0xB6, 0xC7, 0x5A, 0x20, 0x15, 0x01, 0x61, 0x70, 0x70, 0x6C,
+                0x69, 0x63, 0x61, 0x74, 0x69, 0x6F, 0x6E, 0x2F, 0x76, 0x6E, 0x64, 0x2E, 0x62, 0x6C,
+                0x75, 0x65, 0x74, 0x6F, 0x6F, 0x74, 0x68, 0x2E, 0x6C, 0x65, 0x2E, 0x6F, 0x6F, 0x62,
+                0x30, 0x02, 0x1C, 0x01, 0x11, 0x07, 0xB8, 0x9C, 0x57, 0x93, 0xB4, 0xC0, 0x02, 0xA4,
+                0xDB, 0x4F, 0x1E, 0x1B, 0xDD, 0xB7, 0x4D, 0xE3, 0x90, 0x00,
+            ])
+            .expect("failed to process rapdu 12");
         assert!(matches!(res, ReaderApduProgress::Done(_)));
     }
 }

--- a/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
@@ -201,7 +201,7 @@ impl ReaderApduHandoverDriver {
                         "Expected 2-byte Te NDEF length".into(),
                     ));
                 }
-                let te_len = u16::from_be_bytes(*te_len_bytes.first_chunk::<2>().unwrap()) as usize;
+                let te_len = u16::from_be_bytes([te_len_bytes[0], te_len_bytes[1]]) as usize;
                 let chunk_len = te_len.min(self.max_buffer_size);
                 self.state = ReaderHandoverState::WaitingForTeData {
                     total_length: te_len,
@@ -260,7 +260,7 @@ impl ReaderApduHandoverDriver {
                         "Expected 2-byte Hs NDEF length".into(),
                     ));
                 }
-                let hs_len = u16::from_be_bytes(*hs_len_bytes.first_chunk::<2>().unwrap()) as usize;
+                let hs_len = u16::from_be_bytes([hs_len_bytes[0], hs_len_bytes[1]]) as usize;
                 let chunk_len = hs_len.min(self.max_buffer_size);
                 let hr_bytes = hr_bytes.clone();
                 let hr_uuid = *hr_uuid;

--- a/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
@@ -4,9 +4,10 @@ use crate::definitions::device_engagement::nfc::{
         select::{ControlInfo, Occurrence},
         Apdu, FileId,
     },
+    ndef_handover::TNEP_HANDOVER_SERVICE_URI,
     ndef_handover_reader::{
         detect_tp_service, generate_hr_ndef, generate_ts_ndef, parse_te_ndef, ReaderHandoverState,
-        ReaderNegotiatedCarrierInfo, TNEP_HANDOVER_SERVICE_URI,
+        ReaderNegotiatedCarrierInfo,
     },
     util::KnownOrRaw,
     APDU_AID_NDEF_APPLICATION, CC_FILE_TEMPLATE,

--- a/src/definitions/device_engagement/nfc/ndef_handover.rs
+++ b/src/definitions/device_engagement/nfc/ndef_handover.rs
@@ -12,6 +12,8 @@ use crate::definitions::{
     DeviceEngagement,
 };
 
+pub(super) const TNEP_HANDOVER_SERVICE_URI: &str = "urn:nfc:sn:handover";
+
 pub(super) const NFC_MAX_PAYLOAD_SIZE: usize = 255 - 2; // 255 minus 2 bytes for the u16 size at the beginning of the payload
 pub(super) const NFC_MAX_PAYLOAD_SIZE_BYTES: [u8; 2] = (NFC_MAX_PAYLOAD_SIZE as u16).to_be_bytes();
 
@@ -149,17 +151,18 @@ pub struct HandoverResponse {
     pub ndef: Vec<u8>,
 }
 
-pub fn get_static_handover_ndef_response(
-    static_handover_state: StaticHandoverState,
-) -> Result<HandoverResponse, HandoverError> {
+fn build_hs_ndef(
+    static_state: StaticHandoverState,
+    hr_message: Option<ByteStr>,
+) -> Result<(Vec<u8>, NegotiatedCarrierInfo), HandoverError> {
     // TODO: I feel like this logic should maybe not live in crate::definitions?
     let StaticHandoverState {
         uuid,
         private_key,
         security,
-    } = static_handover_state;
+    } = static_state;
 
-    tracing::info!("Static handover with UUID: {}", uuid);
+    tracing::info!("Handover with UUID: {}", uuid);
 
     let device_engagement = DeviceEngagement {
         version: "1.0".into(),
@@ -260,22 +263,117 @@ pub fn get_static_handover_ndef_response(
         .build()
         .map_err(|e| anyhow::anyhow!("Failed to create handover select NDEF record: {e}"))?;
 
-    let response = ndef_rs::NdefMessage::from([hs_record, device_engagement_record, cc_record])
+    let hs_ndef = ndef_rs::NdefMessage::from([hs_record, device_engagement_record, cc_record])
         .to_buffer()
         .map_err(|e| anyhow::anyhow!("Failed to construct NDEF message: {e}"))?;
 
-    let state = HandoverState::Done(Box::new(NegotiatedCarrierInfo {
+    let carrier_info = NegotiatedCarrierInfo {
         uuid,
         ble: BleInfo::StaticHandover {
             private_key,
             device_engagement: Box::new(device_engagement),
         },
-        hs_message: ByteStr::from(response.clone()),
-        hr_message: None,
-    }));
+        hs_message: ByteStr::from(hs_ndef.clone()),
+        hr_message,
+    };
+
+    Ok((hs_ndef, carrier_info))
+}
+
+pub fn get_static_handover_ndef_response(
+    static_state: StaticHandoverState,
+) -> Result<HandoverResponse, HandoverError> {
+    let (ndef, carrier_info) = build_hs_ndef(static_state, None)?;
+    Ok(HandoverResponse {
+        new_state: HandoverState::Done(Box::new(carrier_info)),
+        ndef,
+    })
+}
+
+pub(super) fn generate_tp_ndef() -> Result<Vec<u8>, HandoverError> {
+    let uri_bytes = TNEP_HANDOVER_SERVICE_URI.as_bytes();
+    let payload = [
+        &[0x10u8, uri_bytes.len() as u8] as &[u8],
+        uri_bytes,
+        &[0x00, 0x0F, 0xFF, 0xFF],
+    ]
+    .concat();
+    let tp_record = ndef_rs::NdefRecord::builder()
+        .tnf(ndef_rs::TNF::WellKnown)
+        .payload(&RawPayload {
+            record_type: RecordType::TnepServiceParameter.as_bytes(),
+            payload: &payload,
+        })
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to build Tp NDEF record: {e}"))?;
+    ndef_rs::NdefMessage::from(tp_record)
+        .to_buffer()
+        .map_err(|e| anyhow::anyhow!("Failed to build Tp NDEF message: {e}").into())
+}
+
+pub(super) fn get_negotiated_tp_ndef_response() -> Result<HandoverResponse, HandoverError> {
+    Ok(HandoverResponse {
+        new_state: HandoverState::WaitingForServiceSelect,
+        ndef: generate_tp_ndef()?,
+    })
+}
+
+pub(super) fn handle_ts_write(data: &[u8]) -> Result<HandoverResponse, HandoverError> {
+    let ts_ndef = data.get(2..).ok_or_else(|| {
+        anyhow::anyhow!("Ts UPDATE BINARY payload too short ({} bytes)", data.len())
+    })?;
+    let message = ndef_rs::NdefMessage::decode(ts_ndef)
+        .map_err(|e| anyhow::anyhow!("Failed to decode Ts NDEF: {e}"))?;
+    let ts_record = message
+        .records()
+        .iter()
+        .find(|r| r.record_type() == RecordType::TnepServiceSelect.as_bytes())
+        .ok_or_else(|| anyhow::anyhow!("No Ts record found in UPDATE BINARY payload"))?;
+    let payload = ts_record.payload();
+    let uri_len = *payload
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("Ts record has empty payload"))? as usize;
+    let uri_bytes = payload.get(1..1 + uri_len).ok_or_else(|| {
+        anyhow::anyhow!("Ts record payload too short for declared URI length {uri_len}")
+    })?;
+    let uri = std::str::from_utf8(uri_bytes)
+        .map_err(|e| anyhow::anyhow!("Ts URI is not valid UTF-8: {e}"))?;
+    if uri != TNEP_HANDOVER_SERVICE_URI {
+        return Err(anyhow::anyhow!(
+            "Ts selected unknown service URI: {uri:?} (expected {TNEP_HANDOVER_SERVICE_URI:?})"
+        )
+        .into());
+    }
+
+    let te_record = ndef_rs::NdefRecord::builder()
+        .tnf(ndef_rs::TNF::WellKnown)
+        .payload(&RawPayload {
+            record_type: RecordType::TnepStatus.as_bytes(),
+            payload: &[0x00],
+        })
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to build Te NDEF record: {e}"))?;
+    let te_ndef = ndef_rs::NdefMessage::from(te_record)
+        .to_buffer()
+        .map_err(|e| anyhow::anyhow!("Failed to build Te NDEF message: {e}"))?;
 
     Ok(HandoverResponse {
-        new_state: state,
-        ndef: response,
+        new_state: HandoverState::WaitingForHandoverRequest,
+        ndef: te_ndef,
+    })
+}
+
+pub(super) fn handle_hr_write(
+    data: &[u8],
+    static_state: StaticHandoverState,
+) -> Result<HandoverResponse, HandoverError> {
+    let hr_ndef_bytes = data.get(2..).ok_or_else(|| {
+        anyhow::anyhow!("Hr UPDATE BINARY payload too short ({} bytes)", data.len())
+    })?;
+    let hr_message = ByteStr::from(hr_ndef_bytes.to_vec());
+    let (hs_ndef, carrier_info) = build_hs_ndef(static_state, Some(hr_message))?;
+    Ok(HandoverResponse {
+        new_state: HandoverState::Done(Box::new(carrier_info)),
+        ndef: hs_ndef,
     })
 }

--- a/src/definitions/device_engagement/nfc/ndef_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/ndef_handover_reader.rs
@@ -12,12 +12,14 @@ use crate::{
     definitions::{
         device_engagement::nfc::{
             ble::ad_packet::KnownType,
-            ndef_handover::{LeRole, RecordType},
+            ndef_handover::{LeRole, RawPayload, RecordType},
         },
         helpers::ByteStr,
         DeviceEngagement,
     },
 };
+
+pub(super) const TNEP_HANDOVER_SERVICE_URI: &str = "urn:nfc:sn:handover";
 
 #[derive(Debug, Clone)]
 pub enum ReaderHandoverState {
@@ -26,8 +28,205 @@ pub enum ReaderHandoverState {
     WaitingForCapabilitiesReadResponse,
     WaitingForNdefFileResponse,
     WaitingForNdefReadResponseLength,
-    WaitingForNdefReadResponseData { total_length: usize, data: Vec<u8> },
+    WaitingForNdefReadResponseData {
+        total_length: usize,
+        data: Vec<u8>,
+    },
+    // Negotiated handover states
+    WaitingForTsWriteResponse,
+    WaitingForTeLength,
+    WaitingForTeData {
+        total_length: usize,
+        data: Vec<u8>,
+    },
+    WaitingForHrWriteResponse {
+        hr_bytes: Vec<u8>,
+        hr_uuid: Uuid,
+    },
+    WaitingForHsLength {
+        hr_bytes: Vec<u8>,
+        hr_uuid: Uuid,
+    },
+    WaitingForHsData {
+        total_length: usize,
+        data: Vec<u8>,
+        hr_bytes: Vec<u8>,
+        hr_uuid: Uuid,
+    },
     Done,
+}
+
+/// Returns the TNEP service URI if the NDEF data contains a Well-Known "Tp" (Service Parameter) record.
+pub(super) fn detect_tp_service(data: &[u8]) -> Option<String> {
+    let message = ndef_rs::NdefMessage::decode(data).ok()?;
+    let record = message
+        .records()
+        .iter()
+        .find(|r| r.record_type() == b"Tp" && r.tnf() == TNF::WellKnown)?;
+    // Tp payload: [tnep_version (1)][service_name_length (1)][service_name]...
+    let payload = record.payload();
+    if payload.len() < 2 {
+        return None;
+    }
+    let name_len = payload[1] as usize;
+    if payload.len() < 2 + name_len {
+        return None;
+    }
+    String::from_utf8(payload[2..2 + name_len].to_vec()).ok()
+}
+
+/// Builds the TNEP Service Select (Ts) NDEF message for the given service URI.
+/// Returns raw NDEF bytes (without the 2-byte length prefix used in APDUs).
+pub(super) fn generate_ts_ndef(service_uri: &str) -> Result<Vec<u8>> {
+    let uri_bytes = service_uri.as_bytes();
+    let payload = [[uri_bytes.len() as u8].as_slice(), uri_bytes].concat();
+    let ts_record = NdefRecord::builder()
+        .tnf(TNF::WellKnown)
+        .payload(&RawPayload {
+            record_type: b"Ts",
+            payload: &payload,
+        })
+        .build()
+        .map_err(|e| anyhow!("Failed to build Ts NDEF record: {e}"))?;
+    ndef_rs::NdefMessage::from(ts_record)
+        .to_buffer()
+        .map_err(|e| anyhow!("Failed to build Ts NDEF message: {e}"))
+}
+
+/// Builds the Handover Request (Hr) NDEF message for BLE + NFC carriers.
+/// Returns (raw NDEF bytes, reader UUID used in the BLE OOB record).
+pub(super) fn generate_hr_ndef() -> Result<(Vec<u8>, Uuid)> {
+    let uuid = Uuid::new_v4();
+    let mut uuid_bytes = *uuid.as_bytes();
+    uuid_bytes.reverse(); // big-endian to little-endian for BLE OOB
+
+    // Embedded NDEF inside Hr payload: two Alternative Carrier records
+    let ble_ac_record = NdefRecord::builder()
+        .tnf(TNF::WellKnown)
+        .payload(&RawPayload {
+            record_type: b"ac",
+            payload: &[
+                0x01, // carrier power state: active
+                0x01, // carrier data reference length: 1
+                b'0', // carrier data reference: "0"
+                0x00, // auxiliary data reference count: 0
+            ],
+        })
+        .build()
+        .map_err(|e| anyhow!("Failed to build BLE ac record: {e}"))?;
+
+    let nfc_ac_record = NdefRecord::builder()
+        .tnf(TNF::WellKnown)
+        .payload(&RawPayload {
+            record_type: b"ac",
+            payload: &[
+                0x01, // carrier power state: active
+                0x03, // carrier data reference length: 3
+                b'n', b'f', b'c', // carrier data reference: "nfc"
+                0x00, // auxiliary data reference count: 0
+            ],
+        })
+        .build()
+        .map_err(|e| anyhow!("Failed to build NFC ac record: {e}"))?;
+
+    let embedded_ndef = ndef_rs::NdefMessage::from([ble_ac_record, nfc_ac_record])
+        .to_buffer()
+        .map_err(|e| anyhow!("Failed to build Hr embedded NDEF: {e}"))?;
+
+    let hr_payload = [[0x15u8].as_slice(), &embedded_ndef].concat(); // version 1.5
+
+    let hr_record = NdefRecord::builder()
+        .tnf(TNF::WellKnown)
+        .payload(&RawPayload {
+            record_type: b"Hr",
+            payload: &hr_payload,
+        })
+        .build()
+        .map_err(|e| anyhow!("Failed to build Hr record: {e}"))?;
+
+    // ReaderEngagement CBOR: {0: "1.0"} = a1 00 63 31 2e 30
+    const READER_ENGAGEMENT_CBOR: &[u8] = &[0xa1, 0x00, 0x63, 0x31, 0x2e, 0x30];
+    let reader_engagement_record = NdefRecord::builder()
+        .tnf(TNF::External)
+        .id(b"mdocreader".to_vec())
+        .payload(&RawPayload {
+            record_type: b"iso.org:18013:readerengagement",
+            payload: READER_ENGAGEMENT_CBOR,
+        })
+        .build()
+        .map_err(|e| anyhow!("Failed to build ReaderEngagement record: {e}"))?;
+
+    // BLE LE OOB: LE Role (CentralPreferred) + 128-bit UUID
+    let ble_oob_payload = [
+        [
+            0x02, // length=2 (type + value)
+            0x1c, // type: LE Role
+            0x03, // CentralPreferred
+            0x11, // length=17 (type + 16-byte UUID)
+            0x07, // type: Complete List 128-bit UUIDs
+        ]
+        .as_slice(),
+        &uuid_bytes,
+    ]
+    .concat();
+
+    let ble_oob_record = NdefRecord::builder()
+        .tnf(TNF::MimeMedia)
+        .id(b"0".to_vec())
+        .payload(&RawPayload {
+            record_type: b"application/vnd.bluetooth.le.oob",
+            payload: &ble_oob_payload,
+        })
+        .build()
+        .map_err(|e| anyhow!("Failed to build BLE OOB record: {e}"))?;
+
+    // NFC Carrier Config: per ISO 18013-5 §8.2.2.2 Table 6.
+    // The max cmd/rsp fields are conditional and "shall not be used by the mdoc reader" per spec,
+    // but Google Wallet (and possibly other implementations) parse all 6 bytes unconditionally,
+    // crashing with BufferUnderflowException if only the 1-byte version is present.
+    // Include the full payload as an interop workaround.
+    //   [0x01]              version
+    //   [0x01, 0xFF]        max cmd data field: length=1, value=255 (spec minimum)
+    //   [0x02, 0xFF, 0xFF]  max rsp data field: length=2, value=65535
+    let nfc_config_record = NdefRecord::builder()
+        .tnf(TNF::External)
+        .id(b"nfc".to_vec())
+        .payload(&RawPayload {
+            record_type: b"iso.org:18013:nfc",
+            payload: &[0x01, 0x01, 0xFF, 0x02, 0xFF, 0xFF],
+        })
+        .build()
+        .map_err(|e| anyhow!("Failed to build NFC config record: {e}"))?;
+
+    let hr_ndef = ndef_rs::NdefMessage::from(vec![
+        hr_record,
+        reader_engagement_record,
+        ble_oob_record,
+        nfc_config_record,
+    ])
+    .to_buffer()
+    .map_err(|e| anyhow!("Failed to build Hr NDEF message: {e}"))?;
+
+    Ok((hr_ndef, uuid))
+}
+
+/// Parses a TNEP Status (Te) NDEF message and returns Ok if status is success (0x00).
+pub(super) fn parse_te_ndef(data: &[u8]) -> Result<()> {
+    let message =
+        ndef_rs::NdefMessage::decode(data).map_err(|e| anyhow!("Failed to decode Te NDEF: {e}"))?;
+    let record = message
+        .records()
+        .iter()
+        .find(|r| r.record_type() == b"Te" && r.tnf() == TNF::WellKnown)
+        .ok_or_else(|| anyhow!("No TNEP Status (Te) record found in NDEF message"))?;
+    let status = record
+        .payload()
+        .first()
+        .ok_or_else(|| anyhow!("Te record has empty payload"))?;
+    if *status != 0x00 {
+        bail!("TNEP status error: {status:#x}");
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -53,15 +252,35 @@ impl ReaderNegotiatedCarrierInfo {
             r.record_type() == RecordType::TnepServiceParameter.as_bytes()
                 && r.tnf() == TNF::WellKnown
         }) {
-            None => Self::parse_ndef_message_static(hs_message, ndef_records)
+            None => Self::parse_ndef_records(hs_message, ndef_records, None)
                 .context("Failed to parse static handover NDEF message"),
             Some(_) => bail!("negotiated handover not supported"),
         }
     }
 
-    fn parse_ndef_message_static(
+    /// Parse the Handover Select NDEF message received during negotiated handover.
+    ///
+    /// Per ISO 18013-5 §8.3.3.1.1.2, the mdoc is only required to include a UUID in the Hs when
+    /// it chooses mdoc peripheral server mode. When the mdoc selects central client mode (LE
+    /// Role=0x01 "Only Central"), it omits the UUID from the Hs because it will connect as Central
+    /// using the UUID the reader sent in the Hr. In that case `hr_uuid` is used as the UUID for
+    /// the Peripheral advertisement that the reader broadcasts (§8.3.3.1.1.3).
+    pub(super) fn parse_hs_ndef_message(
+        ndef_response: &[u8],
+        hr_uuid: Uuid,
+    ) -> Result<Self, anyhow::Error> {
+        let hs_message = ByteStr::from(ndef_response.to_vec());
+        let ndef_message =
+            ndef_rs::NdefMessage::decode(ndef_response).context("Failed to decode ndef message")?;
+        let ndef_records = ndef_message.records();
+        Self::parse_ndef_records(hs_message, ndef_records, Some(hr_uuid))
+            .context("Failed to parse negotiated handover Hs NDEF message")
+    }
+
+    fn parse_ndef_records(
         hs_message: ByteStr,
         ndef_records: &[NdefRecord],
+        fallback_uuid: Option<Uuid>,
     ) -> Result<Self, anyhow::Error> {
         if ndef_records.len() < 3 {
             bail!("Not enough NDEF records");
@@ -86,10 +305,19 @@ impl ReaderNegotiatedCarrierInfo {
         let (holder_le_role, uuid, ble_device_address) =
             parse_cc_record(cc_record).context("failed to parse cc record")?;
 
+        let uuid = match (uuid, fallback_uuid) {
+            (Some(u), _) => u,
+            (None, Some(fb)) => {
+                debug!("Hs BLE OOB has no UUID; using Hr UUID as fallback");
+                fb
+            }
+            (None, None) => bail!("Could not find UUID in NDEF record"),
+        };
+
         Ok(Self {
             device_engagement,
             holder_le_role: holder_le_role.context("Could not find LE role in NDEF record")?,
-            uuid: uuid.context("Could not find UUID in NDEF record")?,
+            uuid,
             hs_message,
             hr_message: None,
             ble_device_address,
@@ -183,6 +411,52 @@ mod test {
             get_static_handover_ndef_response(state).expect("failed to get ndef message");
         ReaderNegotiatedCarrierInfo::parse_ndef_message(&handover_response.ndef)
             .expect("failed to parse ndef message");
+    }
+
+    #[test]
+    fn generate_ts_ndef_format() {
+        let ts = generate_ts_ndef(TNEP_HANDOVER_SERVICE_URI).expect("failed to generate Ts NDEF");
+        // From multipaz test data: 0019 d1 02 14 54 73 13 <19 bytes of "urn:nfc:sn:handover">
+        // Without the 2-byte length prefix used in APDUs, the NDEF itself is 25 bytes.
+        let expected = hex::decode("d1021454731375726e3a6e66633a736e3a68616e646f766572").unwrap();
+        assert_eq!(ts, expected);
+    }
+
+    #[test]
+    fn parse_te_ndef_success() {
+        // Well-Known "Te" single record: type_len=2, payload_len=1, type="Te", payload=[0x00]
+        // D1=MB|ME|SR|TNF=WellKnown, 02=type_len, 01=payload_len, 5465="Te", 00=status
+        let te_ndef = hex::decode("d102015465 00".replace(' ', "")).unwrap();
+        parse_te_ndef(&te_ndef).expect("should accept Te with status 0x00");
+    }
+
+    #[test]
+    fn parse_te_ndef_failure() {
+        // Well-Known "Te" single record with non-zero status byte
+        let te_ndef = hex::decode("d102015465 01".replace(' ', "")).unwrap();
+        assert!(parse_te_ndef(&te_ndef).is_err());
+    }
+
+    #[test]
+    fn detect_tp_service_finds_handover() {
+        // Use the exact bytes from the multipaz_negotiated rapdu (excluding 0x9000):
+        let tp_rapdu = &[
+            0xD1u8, 0x02, 0x1A, 0x54, 0x70, 0x10, 0x13, 0x75, 0x72, 0x6E, 0x3A, 0x6E, 0x66, 0x63,
+            0x3A, 0x73, 0x6E, 0x3A, 0x68, 0x61, 0x6E, 0x64, 0x6F, 0x76, 0x65, 0x72, 0x00, 0x00,
+            0x0F, 0xFF, 0xFF,
+        ];
+        let service = detect_tp_service(tp_rapdu);
+        assert_eq!(service.as_deref(), Some(TNEP_HANDOVER_SERVICE_URI));
+    }
+
+    #[test]
+    fn generate_hr_ndef_is_valid() {
+        let (hr_ndef, uuid) = generate_hr_ndef().expect("failed to generate Hr NDEF");
+        assert!(!hr_ndef.is_empty());
+        // The Hr NDEF should be parseable
+        ndef_rs::NdefMessage::decode(hr_ndef).expect("Hr NDEF should be decodable by ndef_rs");
+        // UUID should be a valid v4
+        assert_eq!(uuid.get_version(), Some(uuid::Version::Random));
     }
 
     fn test_sample_cc_record(sample: Vec<u8>) {

--- a/src/definitions/device_engagement/nfc/ndef_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/ndef_handover_reader.rs
@@ -19,8 +19,6 @@ use crate::{
     },
 };
 
-pub(super) const TNEP_HANDOVER_SERVICE_URI: &str = "urn:nfc:sn:handover";
-
 #[derive(Debug, Clone)]
 pub enum ReaderHandoverState {
     WaitingForAidResponse,
@@ -399,7 +397,8 @@ fn parse_cc_record(
 #[cfg(test)]
 mod test {
     use crate::definitions::device_engagement::nfc::{
-        ndef_handover::get_static_handover_ndef_response, StaticHandoverState,
+        ndef_handover::{get_static_handover_ndef_response, TNEP_HANDOVER_SERVICE_URI},
+        StaticHandoverState,
     };
 
     use super::*;


### PR DESCRIPTION
Tested with:
- Google Wallet (but couldn't complete the presentation because I only have an ID card which seems to not be available for proximity sharing)
- Multipaz (by enabling negotiated handover). Interestingly it had slightly different behaviour compared to Google Wallet even though it uses the same SDK