### PR TITLE
Fix infinite loop in negotiated NFC handover reader (Apple Wallet holder)

### DIFF
--- a/src/definitions/device_engagement.rs
+++ b/src/definitions/device_engagement.rs
@@ -225,13 +225,16 @@ impl TryFrom<ciborium::Value> for DeviceEngagement {
                 .map(|(k, v)| Ok((k.into_integer().map_err(|_| Error::CborError)?.into(), v)))
                 .collect::<Result<BTreeMap<_, _>, Error>>()?;
             let device_engagement_version = map.remove(&0);
-            if let Some(ciborium::Value::Text(v)) = device_engagement_version {
-                if v != "1.0" {
+            let version = if let Some(ciborium::Value::Text(v)) = device_engagement_version {
+                // "1.1" (ISO 18013-5 Second Edition) only adds fields a
+                // first-edition reader may ignore (e.g. Capabilities).
+                if !matches!(v.as_str(), "1.0" | "1.1") {
                     return Err(Error::UnsupportedVersion);
                 }
+                v
             } else {
                 return Err(Error::Malformed);
-            }
+            };
             let device_engagement_security = map.remove(&1).ok_or(Error::Malformed)?;
 
             let security: Security =
@@ -257,7 +260,7 @@ impl TryFrom<ciborium::Value> for DeviceEngagement {
             }
 
             let device_engagement = DeviceEngagement {
-                version: "1.0".into(),
+                version,
                 security,
                 device_retrieval_methods,
                 server_retrieval_methods,

--- a/src/definitions/device_engagement.rs
+++ b/src/definitions/device_engagement.rs
@@ -226,8 +226,6 @@ impl TryFrom<ciborium::Value> for DeviceEngagement {
                 .collect::<Result<BTreeMap<_, _>, Error>>()?;
             let device_engagement_version = map.remove(&0);
             let version = if let Some(ciborium::Value::Text(v)) = device_engagement_version {
-                // "1.1" (ISO 18013-5 Second Edition) only adds fields a
-                // first-edition reader may ignore (e.g. Capabilities).
                 if !matches!(v.as_str(), "1.0" | "1.1") {
                     return Err(Error::UnsupportedVersion);
                 }
@@ -235,6 +233,12 @@ impl TryFrom<ciborium::Value> for DeviceEngagement {
             } else {
                 return Err(Error::Malformed);
             };
+            // 18013-5: when key 5 or 6 is present the version shall be "1.1",
+            // otherwise it shall be "1.0".
+            let has_second_edition_keys = map.contains_key(&5) || map.contains_key(&6);
+            if (version == "1.1") != has_second_edition_keys {
+                return Err(Error::Malformed);
+            }
             let device_engagement_security = map.remove(&1).ok_or(Error::Malformed)?;
 
             let security: Security =
@@ -626,6 +630,56 @@ mod test {
         let roundtripped = crate::cbor::from_slice(&bytes).unwrap();
 
         assert_eq!(device_engagement, roundtripped)
+    }
+
+    /// 18013-5: keys 5/6 require version "1.1"; their absence requires "1.0".
+    #[test]
+    fn version_must_match_second_edition_keys() {
+        let key_pair = create_p256_ephemeral_keys().unwrap();
+        let public_key = Tag24::new(key_pair.1).unwrap();
+        let base = DeviceEngagement {
+            version: "1.0".into(),
+            security: Security(1, public_key),
+            device_retrieval_methods: None,
+            server_retrieval_methods: None,
+            protocol_info: None,
+        };
+
+        fn as_map(de: &DeviceEngagement) -> Vec<(ciborium::Value, ciborium::Value)> {
+            match ciborium::Value::from(de.clone()) {
+                ciborium::Value::Map(m) => m,
+                _ => panic!("expected map"),
+            }
+        }
+
+        // 1.0 without keys 5/6: valid
+        let parsed = DeviceEngagement::try_from(ciborium::Value::Map(as_map(&base)))
+            .expect("1.0 without second-edition keys should parse");
+        assert_eq!(parsed.version, "1.0");
+
+        // 1.0 with key 5: invalid
+        let mut m = as_map(&base);
+        m.push((
+            ciborium::Value::Integer(5.into()),
+            ciborium::Value::Array(vec![]),
+        ));
+        assert!(DeviceEngagement::try_from(ciborium::Value::Map(m)).is_err());
+
+        // 1.1 without keys 5/6: invalid
+        let mut m = as_map(&base);
+        m[0].1 = ciborium::Value::Text("1.1".into());
+        assert!(DeviceEngagement::try_from(ciborium::Value::Map(m)).is_err());
+
+        // 1.1 with key 6: valid
+        let mut m = as_map(&base);
+        m[0].1 = ciborium::Value::Text("1.1".into());
+        m.push((
+            ciborium::Value::Integer(6.into()),
+            ciborium::Value::Map(vec![]),
+        ));
+        let parsed = DeviceEngagement::try_from(ciborium::Value::Map(m))
+            .expect("1.1 with second-edition keys should parse");
+        assert_eq!(parsed.version, "1.1");
     }
 
     #[test]

--- a/src/definitions/device_engagement/nfc/apdu.rs
+++ b/src/definitions/device_engagement/nfc/apdu.rs
@@ -244,7 +244,10 @@ impl<'a> Apdu<'a> {
                         if file_id_raw.len() != 2 {
                             apdu_fail!(ResponseCode::IncorrectLength);
                         }
-                        let file_id = u16::from_be_bytes([file_id_raw[0], file_id_raw[1]]).into();
+                        let file_id = KnownOrRaw::from_raw(u16::from_be_bytes([
+                            file_id_raw[0],
+                            file_id_raw[1],
+                        ]));
                         Apdu::SelectFile {
                             occurrence,
                             control_info,

--- a/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
@@ -554,6 +554,128 @@ mod test {
         }
     }
 
+    /// Real Apple Wallet Handover Select NDEF (194 bytes), from a device log.
+    /// DeviceEngagement is version "1.1" (ISO 18013-5 Second Edition) with
+    /// the Capabilities field; the BLE OOB record carries only the LE Role.
+    const APPLE_HS_NDEF: &[u8] = &[
+        0x91, 0x02, 0x0F, 0x48, 0x73, 0x15, 0xD1, 0x02, 0x09, 0x61, 0x63, 0x01, 0x01, 0x30, 0x01,
+        0x04, 0x6D, 0x64, 0x6F, 0x63, 0x1A, 0x20, 0x03, 0x01, 0x61, 0x70, 0x70, 0x6C, 0x69, 0x63,
+        0x61, 0x74, 0x69, 0x6F, 0x6E, 0x2F, 0x76, 0x6E, 0x64, 0x2E, 0x62, 0x6C, 0x75, 0x65, 0x74,
+        0x6F, 0x6F, 0x74, 0x68, 0x2E, 0x6C, 0x65, 0x2E, 0x6F, 0x6F, 0x62, 0x30, 0x02, 0x1C, 0x01,
+        0x5C, 0x1E, 0x60, 0x04, 0x69, 0x73, 0x6F, 0x2E, 0x6F, 0x72, 0x67, 0x3A, 0x31, 0x38, 0x30,
+        0x31, 0x33, 0x3A, 0x64, 0x65, 0x76, 0x69, 0x63, 0x65, 0x65, 0x6E, 0x67, 0x61, 0x67, 0x65,
+        0x6D, 0x65, 0x6E, 0x74, 0x6D, 0x64, 0x6F, 0x63, 0xA4, 0x00, 0x63, 0x31, 0x2E, 0x31, 0x01,
+        0x82, 0x01, 0xD8, 0x18, 0x58, 0x4B, 0xA4, 0x01, 0x02, 0x20, 0x01, 0x21, 0x58, 0x20, 0x19,
+        0xB9, 0xEA, 0x44, 0x60, 0x42, 0x2C, 0x7D, 0x9D, 0x31, 0x4B, 0x77, 0x40, 0x80, 0x69, 0xDF,
+        0x57, 0x5B, 0x36, 0xF3, 0x72, 0x03, 0x07, 0xA6, 0xA0, 0x36, 0xFE, 0xC9, 0xEC, 0x6F, 0x52,
+        0x41, 0x22, 0x58, 0x20, 0x6C, 0x33, 0x4A, 0x64, 0x1D, 0x65, 0xE0, 0x6E, 0xDE, 0xB6, 0xC2,
+        0x17, 0xEC, 0x4B, 0xE4, 0xF5, 0x02, 0x4E, 0x3A, 0x63, 0x3A, 0x06, 0x77, 0x5C, 0x86, 0x73,
+        0xA0, 0x31, 0xCE, 0x9F, 0x44, 0x92, 0x05, 0x80, 0x06, 0xA2, 0x03, 0xF5, 0x04, 0xF5,
+    ];
+
+    /// Drives the real Pixel-reader → Apple-Wallet-holder transcript through
+    /// the Hr write ack, leaving the driver waiting for the Hs length.
+    fn drive_apple_to_hr_ack() -> ReaderApduHandoverDriver {
+        let mut driver = ReaderApduHandoverDriver::new().0;
+        driver.process_rapdu(&[0x90, 0x00]).expect("aid select ack");
+        driver.process_rapdu(&[0x90, 0x00]).expect("cc select ack");
+        driver
+            .process_rapdu(&[
+                0x00, 0x0F, 0x20, 0x04, 0x00, 0x04, 0x00, 0x04, 0x06, 0xE1, 0x04, 0x08, 0x02, 0x00,
+                0x00, 0x90, 0x00,
+            ])
+            .expect("cc read");
+        driver
+            .process_rapdu(&[0x90, 0x00])
+            .expect("ndef select ack");
+        driver
+            .process_rapdu(&[0x00, 0x1F, 0x90, 0x00])
+            .expect("ndef length");
+        driver
+            .process_rapdu(&[
+                0xD1, 0x02, 0x1A, 0x54, 0x70, 0x10, 0x13, 0x75, 0x72, 0x6E, 0x3A, 0x6E, 0x66, 0x63,
+                0x3A, 0x73, 0x6E, 0x3A, 0x68, 0x61, 0x6E, 0x64, 0x6F, 0x76, 0x65, 0x72, 0x00, 0x14,
+                0x0F, 0x08, 0x00, 0x90, 0x00,
+            ])
+            .expect("tp record");
+        driver.process_rapdu(&[0x90, 0x00]).expect("ts write ack");
+        driver
+            .process_rapdu(&[0x00, 0x06, 0x90, 0x00])
+            .expect("te length");
+        driver
+            .process_rapdu(&[0xD1, 0x02, 0x01, 0x54, 0x65, 0x00, 0x90, 0x00])
+            .expect("te data");
+        driver.process_rapdu(&[0x90, 0x00]).expect("hr write ack");
+        driver
+    }
+
+    /// Regression: Apple Wallet negotiated handover returns Hs NDEF length = 0
+    /// right after the Hr write (Handover Select not ready yet — a legal TNEP
+    /// "service waiting" state). The driver must NOT loop forever on this.
+    /// On device, the unfixed driver issued 1100+ reads until the NFC link died.
+    #[test_log::test]
+    fn apple_wallet_hs_length_zero_does_not_loop_forever() {
+        let mut driver = drive_apple_to_hr_ack();
+        // Hs length read returns 0 — Hs not ready yet.
+        let mut progress = driver
+            .process_rapdu(&[0x00, 0x00, 0x90, 0x00])
+            .expect("hs length poll");
+        // Real device then answered every further (out-of-range) ReadBinary
+        // with 8 zero bytes; the driver must reach Done or Err within a
+        // bounded number of steps no matter what comes back.
+        let mut steps = 0;
+        loop {
+            if let ReaderApduProgress::Done(_) = progress {
+                break;
+            }
+            steps += 1;
+            assert!(
+                steps < 64,
+                "driver looped {steps}x on Hs length=0 without resolving — regression"
+            );
+            progress = match driver
+                .process_rapdu(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90, 0x00])
+            {
+                Ok(p) => p,
+                Err(_) => break, // a bounded Err is acceptable (stop-the-bleed)
+            };
+        }
+    }
+
+    /// Success path from the same device log: the Hs length reads 0 while
+    /// Apple prepares its Handover Select, then the real length appears and
+    /// the Hs (194 bytes, DeviceEngagement v1.1) parses to completion.
+    #[test_log::test]
+    fn apple_wallet_hs_polls_then_done() {
+        let mut driver = drive_apple_to_hr_ack();
+        for _ in 0..3 {
+            let res = driver
+                .process_rapdu(&[0x00, 0x00, 0x90, 0x00])
+                .expect("hs length poll");
+            match res {
+                ReaderApduProgress::InProgress(bytes) => {
+                    assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x00, 0x02]);
+                }
+                _ => panic!("expected Hs length re-read, got {res:?}"),
+            }
+        }
+        let res = driver
+            .process_rapdu(&[0x00, 0xC2, 0x90, 0x00])
+            .expect("hs length");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x02, 0xC2]);
+            }
+            _ => panic!("expected READ BINARY for Hs data, got {res:?}"),
+        }
+        let hs_rapdu = [APPLE_HS_NDEF, &[0x90, 0x00]].concat();
+        let res = driver.process_rapdu(&hs_rapdu).expect("hs data");
+        let ReaderApduProgress::Done(carrier_info) = res else {
+            panic!("expected Done, got {res:?}");
+        };
+        assert_eq!(carrier_info.device_engagement.version, "1.1");
+    }
+
     /// NDEF messages larger than one APDU chunk must be read at the file
     /// offset (NLEN field + message offset), and each chunk's Le must fit in
     /// a short APDU.

--- a/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
@@ -69,6 +69,10 @@ pub struct ReaderApduHandoverDriver {
     max_buffer_size: usize,
     /// Consecutive reads that made no progress; see [MAX_NO_PROGRESS_POLLS].
     no_progress_polls: usize,
+    /// TNEP minimum waiting time, from the holder's Tp record once parsed.
+    t_wait_ms: u32,
+    /// See [Self::recommended_delay_ms].
+    pending_delay_ms: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -92,6 +96,10 @@ impl ReaderApduHandoverDriver {
             // Le=8). Extended APDUs would allow more if ever needed.
             max_buffer_size: 255,
             no_progress_polls: 0,
+            // Conservative default until the holder's Tp record provides WT;
+            // also used on the static-handover path, which has no Tp.
+            t_wait_ms: 5,
+            pending_delay_ms: 0,
         };
         let apdu = Apdu::SelectAid {
             occurrence: Occurrence::FirstOrOnly,
@@ -101,7 +109,16 @@ impl ReaderApduHandoverDriver {
         (self_, apdu.to_bytes())
     }
 
+    /// Recommended delay before transmitting the command returned by the last
+    /// [Self::process_rapdu] call, per TNEP's minimum waiting time. 0 when no
+    /// wait is needed. Callers that ignore it still terminate (the no-progress
+    /// budget bounds polling) but poll the holder harder than TNEP intends.
+    pub fn recommended_delay_ms(&self) -> u32 {
+        self.pending_delay_ms
+    }
+
     pub fn process_rapdu(&mut self, rapdu: &[u8]) -> Result<ReaderApduProgress, ReaderApduError> {
+        self.pending_delay_ms = 0;
         let rapdu = match apdu::Response::try_from(rapdu) {
             Ok(r) => r,
             Err(e) => return Err(ReaderApduError::InvalidApduResponse(e.into())),
@@ -167,6 +184,7 @@ impl ReaderApduHandoverDriver {
                 let ndef_len = u16::from_be_bytes(*ndef_recv.first_chunk::<2>().unwrap()) as usize;
                 // Empty NDEF message: the holder hasn't produced it yet; re-read.
                 if ndef_len == 0 {
+                    self.pending_delay_ms = self.t_wait_ms;
                     return poll_empty_ndef(&mut self.no_progress_polls);
                 }
                 self.no_progress_polls = 0;
@@ -190,7 +208,8 @@ impl ReaderApduHandoverDriver {
                 let offset = data.len();
                 if &offset == total_length {
                     self.no_progress_polls = 0;
-                    if detect_tp_service(&data).is_some() {
+                    if let Some(tp) = detect_tp_service(&data) {
+                        self.t_wait_ms = tp.t_wait_ms;
                         // Negotiated handover: write Ts (Service Select)
                         let ts_ndef = generate_ts_ndef(TNEP_HANDOVER_SERVICE_URI)
                             .map_err(ReaderApduError::NdefMessageError)?;
@@ -216,6 +235,7 @@ impl ReaderApduHandoverDriver {
                     if made_progress {
                         self.no_progress_polls = 0;
                     } else {
+                        self.pending_delay_ms = self.t_wait_ms;
                         bump_no_progress(&mut self.no_progress_polls)?;
                     }
                     let chunk_len = if total_length - offset <= self.max_buffer_size {
@@ -237,7 +257,9 @@ impl ReaderApduHandoverDriver {
             }
             // Negotiated handover states
             ReaderHandoverState::WaitingForTsWriteResponse => {
-                // Ts was written (0x9000 received); read the Te NDEF length
+                // Ts was written (0x9000 received); wait t_wait then read the
+                // Te NDEF length (TNEP §5.3).
+                self.pending_delay_ms = self.t_wait_ms;
                 self.state = ReaderHandoverState::WaitingForTeLength;
                 Ok(ReaderApduProgress::InProgress(
                     Apdu::ReadBinary { slice: 0..2 }.to_bytes(),
@@ -253,6 +275,7 @@ impl ReaderApduHandoverDriver {
                 let te_len = u16::from_be_bytes([te_len_bytes[0], te_len_bytes[1]]) as usize;
                 // Empty NDEF message: the holder hasn't produced the Te yet; re-read.
                 if te_len == 0 {
+                    self.pending_delay_ms = self.t_wait_ms;
                     return poll_empty_ndef(&mut self.no_progress_polls);
                 }
                 self.no_progress_polls = 0;
@@ -295,6 +318,7 @@ impl ReaderApduHandoverDriver {
                     if made_progress {
                         self.no_progress_polls = 0;
                     } else {
+                        self.pending_delay_ms = self.t_wait_ms;
                         bump_no_progress(&mut self.no_progress_polls)?;
                     }
                     let chunk_len = (total_length - offset).min(self.max_buffer_size);
@@ -311,9 +335,11 @@ impl ReaderApduHandoverDriver {
                 }
             }
             ReaderHandoverState::WaitingForHrWriteResponse { hr_bytes, hr_uuid } => {
-                // Hr was written (0x9000 received); read the Hs NDEF length
+                // Hr was written (0x9000 received); wait t_wait then read the
+                // Hs NDEF length (TNEP §5.3).
                 let hr_bytes = hr_bytes.clone();
                 let hr_uuid = *hr_uuid;
+                self.pending_delay_ms = self.t_wait_ms;
                 self.state = ReaderHandoverState::WaitingForHsLength { hr_bytes, hr_uuid };
                 Ok(ReaderApduProgress::InProgress(
                     Apdu::ReadBinary { slice: 0..2 }.to_bytes(),
@@ -331,6 +357,7 @@ impl ReaderApduHandoverDriver {
                 // (observed with Apple Wallet, which acks the Hr before its
                 // Handover Select is ready); re-read until it appears.
                 if hs_len == 0 {
+                    self.pending_delay_ms = self.t_wait_ms;
                     return poll_empty_ndef(&mut self.no_progress_polls);
                 }
                 self.no_progress_polls = 0;
@@ -376,6 +403,7 @@ impl ReaderApduHandoverDriver {
                     if made_progress {
                         self.no_progress_polls = 0;
                     } else {
+                        self.pending_delay_ms = self.t_wait_ms;
                         bump_no_progress(&mut self.no_progress_polls)?;
                     }
                     let chunk_len = (total_length - offset).min(self.max_buffer_size);
@@ -645,9 +673,11 @@ mod test {
     /// Success path from the same device log: the Hs length reads 0 while
     /// Apple prepares its Handover Select, then the real length appears and
     /// the Hs (194 bytes, DeviceEngagement v1.1) parses to completion.
+    /// Apple's Tp advertises WT=0x14, so each poll carries a 16 ms wait.
     #[test_log::test]
     fn apple_wallet_hs_polls_then_done() {
         let mut driver = drive_apple_to_hr_ack();
+        assert_eq!(driver.recommended_delay_ms(), 16); // post-Hr first read
         for _ in 0..3 {
             let res = driver
                 .process_rapdu(&[0x00, 0x00, 0x90, 0x00])
@@ -658,6 +688,7 @@ mod test {
                 }
                 _ => panic!("expected Hs length re-read, got {res:?}"),
             }
+            assert_eq!(driver.recommended_delay_ms(), 16);
         }
         let res = driver
             .process_rapdu(&[0x00, 0xC2, 0x90, 0x00])
@@ -668,6 +699,8 @@ mod test {
             }
             _ => panic!("expected READ BINARY for Hs data, got {res:?}"),
         }
+        // Normal progress: no wait needed before the data read.
+        assert_eq!(driver.recommended_delay_ms(), 0);
         let hs_rapdu = [APPLE_HS_NDEF, &[0x90, 0x00]].concat();
         let res = driver.process_rapdu(&hs_rapdu).expect("hs data");
         let ReaderApduProgress::Done(carrier_info) = res else {

--- a/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
@@ -118,7 +118,7 @@ impl ReaderApduHandoverDriver {
     }
 
     /// Override how many consecutive empty reads are tolerated before the
-    /// handover fails (default [MAX_NO_PROGRESS_POLLS]).
+    /// handover fails (default `MAX_NO_PROGRESS_POLLS`, 100).
     pub fn set_max_no_progress_polls(&mut self, max: usize) {
         self.max_no_progress_polls = max;
     }

--- a/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
@@ -43,19 +43,17 @@ pub enum ReaderApduError {
 /// exceeds TNEP minimum waiting times so no extra delay is inserted.
 const MAX_NO_PROGRESS_POLLS: usize = 100;
 
-fn bump_no_progress(polls: &mut usize) -> Result<(), ReaderApduError> {
+fn bump_no_progress(polls: &mut usize, max: usize) -> Result<(), ReaderApduError> {
     *polls += 1;
-    if *polls > MAX_NO_PROGRESS_POLLS {
-        return Err(ReaderApduError::ResponsePollLimitExceeded(
-            MAX_NO_PROGRESS_POLLS,
-        ));
+    if *polls > max {
+        return Err(ReaderApduError::ResponsePollLimitExceeded(max));
     }
     Ok(())
 }
 
 /// Re-read the 2-byte NDEF length after an empty NDEF message.
-fn poll_empty_ndef(polls: &mut usize) -> Result<ReaderApduProgress, ReaderApduError> {
-    bump_no_progress(polls)?;
+fn poll_empty_ndef(polls: &mut usize, max: usize) -> Result<ReaderApduProgress, ReaderApduError> {
+    bump_no_progress(polls, max)?;
     Ok(ReaderApduProgress::InProgress(
         Apdu::ReadBinary { slice: 0..2 }.to_bytes(),
     ))
@@ -67,8 +65,9 @@ pub struct ReaderApduHandoverDriver {
     /// Maximum amount of bytes in an APDU command or response. Used to be able to transmit large
     /// amount of data in multiple chunks.
     max_buffer_size: usize,
-    /// Consecutive reads that made no progress; see [MAX_NO_PROGRESS_POLLS].
+    /// Consecutive reads that made no progress; see [Self::set_max_no_progress_polls].
     no_progress_polls: usize,
+    max_no_progress_polls: usize,
     /// TNEP minimum waiting time, from the holder's Tp record once parsed.
     t_wait_ms: u32,
     /// See [Self::recommended_delay_ms].
@@ -96,6 +95,7 @@ impl ReaderApduHandoverDriver {
             // Le=8). Extended APDUs would allow more if ever needed.
             max_buffer_size: 255,
             no_progress_polls: 0,
+            max_no_progress_polls: MAX_NO_PROGRESS_POLLS,
             // Conservative default until the holder's Tp record provides WT;
             // also used on the static-handover path, which has no Tp.
             t_wait_ms: 5,
@@ -115,6 +115,12 @@ impl ReaderApduHandoverDriver {
     /// budget bounds polling) but poll the holder harder than TNEP intends.
     pub fn recommended_delay_ms(&self) -> u32 {
         self.pending_delay_ms
+    }
+
+    /// Override how many consecutive empty reads are tolerated before the
+    /// handover fails (default [MAX_NO_PROGRESS_POLLS]).
+    pub fn set_max_no_progress_polls(&mut self, max: usize) {
+        self.max_no_progress_polls = max;
     }
 
     pub fn process_rapdu(&mut self, rapdu: &[u8]) -> Result<ReaderApduProgress, ReaderApduError> {
@@ -164,6 +170,11 @@ impl ReaderApduHandoverDriver {
                         FileId::NdefFile as u16,
                     ));
                 }
+                // Honor the holder's advertised maximum R-APDU size (MLe,
+                // CC bytes 3-4), capped at the short-APDU Le limit and
+                // floored at the T4T minimum.
+                let mle = u16::from_be_bytes([ndef_recv[3], ndef_recv[4]]) as usize;
+                self.max_buffer_size = mle.clamp(15, 255);
                 let apdu = Apdu::SelectFile {
                     occurrence: Occurrence::FirstOrOnly,
                     control_info: ControlInfo::NoResponse,
@@ -185,7 +196,10 @@ impl ReaderApduHandoverDriver {
                 // Empty NDEF message: the holder hasn't produced it yet; re-read.
                 if ndef_len == 0 {
                     self.pending_delay_ms = self.t_wait_ms;
-                    return poll_empty_ndef(&mut self.no_progress_polls);
+                    return poll_empty_ndef(
+                        &mut self.no_progress_polls,
+                        self.max_no_progress_polls,
+                    );
                 }
                 self.no_progress_polls = 0;
                 let chunk_len = if ndef_len <= self.max_buffer_size {
@@ -209,6 +223,10 @@ impl ReaderApduHandoverDriver {
                 if &offset == total_length {
                     self.no_progress_polls = 0;
                     if let Some(tp) = detect_tp_service(&data) {
+                        debug!(
+                            "TNEP service {:?} advertised; t_wait = {} ms",
+                            tp.service_name, tp.t_wait_ms
+                        );
                         self.t_wait_ms = tp.t_wait_ms;
                         // Negotiated handover: write Ts (Service Select)
                         let ts_ndef = generate_ts_ndef(TNEP_HANDOVER_SERVICE_URI)
@@ -236,7 +254,7 @@ impl ReaderApduHandoverDriver {
                         self.no_progress_polls = 0;
                     } else {
                         self.pending_delay_ms = self.t_wait_ms;
-                        bump_no_progress(&mut self.no_progress_polls)?;
+                        bump_no_progress(&mut self.no_progress_polls, self.max_no_progress_polls)?;
                     }
                     let chunk_len = if total_length - offset <= self.max_buffer_size {
                         total_length - offset
@@ -276,7 +294,10 @@ impl ReaderApduHandoverDriver {
                 // Empty NDEF message: the holder hasn't produced the Te yet; re-read.
                 if te_len == 0 {
                     self.pending_delay_ms = self.t_wait_ms;
-                    return poll_empty_ndef(&mut self.no_progress_polls);
+                    return poll_empty_ndef(
+                        &mut self.no_progress_polls,
+                        self.max_no_progress_polls,
+                    );
                 }
                 self.no_progress_polls = 0;
                 let chunk_len = te_len.min(self.max_buffer_size);
@@ -319,7 +340,7 @@ impl ReaderApduHandoverDriver {
                         self.no_progress_polls = 0;
                     } else {
                         self.pending_delay_ms = self.t_wait_ms;
-                        bump_no_progress(&mut self.no_progress_polls)?;
+                        bump_no_progress(&mut self.no_progress_polls, self.max_no_progress_polls)?;
                     }
                     let chunk_len = (total_length - offset).min(self.max_buffer_size);
                     self.state = ReaderHandoverState::WaitingForTeData {
@@ -358,7 +379,10 @@ impl ReaderApduHandoverDriver {
                 // Handover Select is ready); re-read until it appears.
                 if hs_len == 0 {
                     self.pending_delay_ms = self.t_wait_ms;
-                    return poll_empty_ndef(&mut self.no_progress_polls);
+                    return poll_empty_ndef(
+                        &mut self.no_progress_polls,
+                        self.max_no_progress_polls,
+                    );
                 }
                 self.no_progress_polls = 0;
                 let chunk_len = hs_len.min(self.max_buffer_size);
@@ -404,7 +428,7 @@ impl ReaderApduHandoverDriver {
                         self.no_progress_polls = 0;
                     } else {
                         self.pending_delay_ms = self.t_wait_ms;
-                        bump_no_progress(&mut self.no_progress_polls)?;
+                        bump_no_progress(&mut self.no_progress_polls, self.max_no_progress_polls)?;
                     }
                     let chunk_len = (total_length - offset).min(self.max_buffer_size);
                     let hr_bytes = hr_bytes.clone();
@@ -707,6 +731,53 @@ mod test {
             panic!("expected Done, got {res:?}");
         };
         assert_eq!(carrier_info.device_engagement.version, "1.1");
+    }
+
+    /// A holder advertising a small MLe in its CC file must be read in
+    /// correspondingly small chunks.
+    #[test_log::test]
+    fn small_mle_limits_chunk_size() {
+        let mut driver = ReaderApduHandoverDriver::new().0;
+        driver.process_rapdu(&[0x90, 0x00]).expect("aid select ack");
+        driver.process_rapdu(&[0x90, 0x00]).expect("cc select ack");
+        // CC with MLe = 32 (bytes 3-4)
+        driver
+            .process_rapdu(&[
+                0x00, 0x0F, 0x20, 0x00, 0x20, 0x7F, 0xFF, 0x04, 0x06, 0xE1, 0x04, 0x7F, 0xFF, 0x00,
+                0x00, 0x90, 0x00,
+            ])
+            .expect("cc read");
+        driver
+            .process_rapdu(&[0x90, 0x00])
+            .expect("ndef select ack");
+        // NLEN = 100 → first chunk capped at MLe: 32 bytes at file offset 2
+        let res = driver
+            .process_rapdu(&[0x00, 0x64, 0x90, 0x00])
+            .expect("ndef length");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x02, 0x20]);
+            }
+            _ => panic!("expected READ BINARY capped to MLe, got {res:?}"),
+        }
+    }
+
+    /// The poll budget must be overridable by the caller.
+    #[test_log::test]
+    fn poll_budget_is_configurable() {
+        let mut driver = drive_apple_to_hr_ack();
+        driver.set_max_no_progress_polls(2);
+        for _ in 0..2 {
+            let res = driver
+                .process_rapdu(&[0x00, 0x00, 0x90, 0x00])
+                .expect("within budget");
+            assert!(matches!(res, ReaderApduProgress::InProgress(_)));
+        }
+        let res = driver.process_rapdu(&[0x00, 0x00, 0x90, 0x00]);
+        assert!(matches!(
+            res,
+            Err(ReaderApduError::ResponsePollLimitExceeded(2))
+        ));
     }
 
     /// NDEF messages larger than one APDU chunk must be read at the file

--- a/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
@@ -31,6 +31,34 @@ pub enum ReaderApduError {
     NegativeApduResponse(String),
     #[error("NDEF decoding failure: {0}")]
     NdefMessageError(#[from] anyhow::Error),
+    #[error("Holder still had no NDEF message after {0} reads")]
+    ResponsePollLimitExceeded(usize),
+    #[error("Holder returned more data than expected: {got} > {expected}")]
+    UnexpectedDataLength { got: usize, expected: usize },
+}
+
+/// Upper bound on consecutive reads that make no progress (empty NDEF message
+/// or empty payload). TNEP signals "response not ready yet" with an empty NDEF
+/// message and expects the reader to poll; the NFC round trip (≥~10ms) already
+/// exceeds TNEP minimum waiting times so no extra delay is inserted.
+const MAX_NO_PROGRESS_POLLS: usize = 100;
+
+fn bump_no_progress(polls: &mut usize) -> Result<(), ReaderApduError> {
+    *polls += 1;
+    if *polls > MAX_NO_PROGRESS_POLLS {
+        return Err(ReaderApduError::ResponsePollLimitExceeded(
+            MAX_NO_PROGRESS_POLLS,
+        ));
+    }
+    Ok(())
+}
+
+/// Re-read the 2-byte NDEF length after an empty NDEF message.
+fn poll_empty_ndef(polls: &mut usize) -> Result<ReaderApduProgress, ReaderApduError> {
+    bump_no_progress(polls)?;
+    Ok(ReaderApduProgress::InProgress(
+        Apdu::ReadBinary { slice: 0..2 }.to_bytes(),
+    ))
 }
 
 #[derive(Debug, Clone)]
@@ -39,6 +67,8 @@ pub struct ReaderApduHandoverDriver {
     /// Maximum amount of bytes in an APDU command or response. Used to be able to transmit large
     /// amount of data in multiple chunks.
     max_buffer_size: usize,
+    /// Consecutive reads that made no progress; see [MAX_NO_PROGRESS_POLLS].
+    no_progress_polls: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -61,6 +91,7 @@ impl ReaderApduHandoverDriver {
             // future we might have to make it configurable if we see either the need to use
             // extended APDUs or encounter discrepancies between platforms.
             max_buffer_size: 264,
+            no_progress_polls: 0,
         };
         let apdu = Apdu::SelectAid {
             occurrence: Occurrence::FirstOrOnly,
@@ -134,6 +165,11 @@ impl ReaderApduHandoverDriver {
                     return Err(ReaderApduError::InvalidApduResponse("Expected to receive length indication, but payload doesn't have a payload of 2 bytes".into()));
                 }
                 let ndef_len = u16::from_be_bytes(*ndef_recv.first_chunk::<2>().unwrap()) as usize;
+                // Empty NDEF message: the holder hasn't produced it yet; re-read.
+                if ndef_len == 0 {
+                    return poll_empty_ndef(&mut self.no_progress_polls);
+                }
+                self.no_progress_polls = 0;
                 let chunk_len = if ndef_len <= self.max_buffer_size {
                     ndef_len
                 } else {
@@ -149,10 +185,11 @@ impl ReaderApduHandoverDriver {
                 Ok(ReaderApduProgress::InProgress(apdu.to_bytes()))
             }
             ReaderHandoverState::WaitingForNdefReadResponseData { total_length, data } => {
-                let ndef_recv = rapdu.payload;
-                let data = [data, ndef_recv.as_slice()].concat();
+                let made_progress = !rapdu.payload.is_empty();
+                let data = [data, rapdu.payload.as_slice()].concat();
                 let offset = data.len();
                 if &offset == total_length {
+                    self.no_progress_polls = 0;
                     if detect_tp_service(&data).is_some() {
                         // Negotiated handover: write Ts (Service Select)
                         let ts_ndef = generate_ts_ndef(TNEP_HANDOVER_SERVICE_URI)
@@ -170,7 +207,17 @@ impl ReaderApduHandoverDriver {
                         self.state = ReaderHandoverState::Done;
                         Ok(ReaderApduProgress::Done(Box::new(carrier_info)))
                     }
+                } else if &offset > total_length {
+                    Err(ReaderApduError::UnexpectedDataLength {
+                        got: offset,
+                        expected: *total_length,
+                    })
                 } else {
+                    if made_progress {
+                        self.no_progress_polls = 0;
+                    } else {
+                        bump_no_progress(&mut self.no_progress_polls)?;
+                    }
                     let chunk_len = if total_length - offset <= self.max_buffer_size {
                         total_length - offset
                     } else {
@@ -202,6 +249,11 @@ impl ReaderApduHandoverDriver {
                     ));
                 }
                 let te_len = u16::from_be_bytes([te_len_bytes[0], te_len_bytes[1]]) as usize;
+                // Empty NDEF message: the holder hasn't produced the Te yet; re-read.
+                if te_len == 0 {
+                    return poll_empty_ndef(&mut self.no_progress_polls);
+                }
+                self.no_progress_polls = 0;
                 let chunk_len = te_len.min(self.max_buffer_size);
                 self.state = ReaderHandoverState::WaitingForTeData {
                     total_length: te_len,
@@ -215,9 +267,11 @@ impl ReaderApduHandoverDriver {
                 ))
             }
             ReaderHandoverState::WaitingForTeData { total_length, data } => {
+                let made_progress = !rapdu.payload.is_empty();
                 let data = [data, rapdu.payload.as_slice()].concat();
                 let offset = data.len();
                 if &offset == total_length {
+                    self.no_progress_polls = 0;
                     // Te received; check TNEP status then write Hr
                     parse_te_ndef(&data).map_err(ReaderApduError::NdefMessageError)?;
                     let (hr_ndef, hr_uuid) =
@@ -230,7 +284,17 @@ impl ReaderApduHandoverDriver {
                     self.state =
                         ReaderHandoverState::WaitingForHrWriteResponse { hr_bytes, hr_uuid };
                     Ok(ReaderApduProgress::InProgress(hr_apdu.to_bytes()))
+                } else if &offset > total_length {
+                    Err(ReaderApduError::UnexpectedDataLength {
+                        got: offset,
+                        expected: *total_length,
+                    })
                 } else {
+                    if made_progress {
+                        self.no_progress_polls = 0;
+                    } else {
+                        bump_no_progress(&mut self.no_progress_polls)?;
+                    }
                     let chunk_len = (total_length - offset).min(self.max_buffer_size);
                     self.state = ReaderHandoverState::WaitingForTeData {
                         total_length: *total_length,
@@ -261,6 +325,13 @@ impl ReaderApduHandoverDriver {
                     ));
                 }
                 let hs_len = u16::from_be_bytes([hs_len_bytes[0], hs_len_bytes[1]]) as usize;
+                // Empty NDEF message: the holder is still preparing the Hs
+                // (observed with Apple Wallet, which acks the Hr before its
+                // Handover Select is ready); re-read until it appears.
+                if hs_len == 0 {
+                    return poll_empty_ndef(&mut self.no_progress_polls);
+                }
+                self.no_progress_polls = 0;
                 let chunk_len = hs_len.min(self.max_buffer_size);
                 let hr_bytes = hr_bytes.clone();
                 let hr_uuid = *hr_uuid;
@@ -283,16 +354,28 @@ impl ReaderApduHandoverDriver {
                 hr_bytes,
                 hr_uuid,
             } => {
+                let made_progress = !rapdu.payload.is_empty();
                 let data = [data, rapdu.payload.as_slice()].concat();
                 let offset = data.len();
                 if &offset == total_length {
+                    self.no_progress_polls = 0;
                     let mut carrier_info =
                         ReaderNegotiatedCarrierInfo::parse_hs_ndef_message(&data, *hr_uuid)
                             .map_err(ReaderApduError::NdefMessageError)?;
                     carrier_info.hr_message = Some(ByteStr::from(hr_bytes.clone()));
                     self.state = ReaderHandoverState::Done;
                     Ok(ReaderApduProgress::Done(Box::new(carrier_info)))
+                } else if &offset > total_length {
+                    Err(ReaderApduError::UnexpectedDataLength {
+                        got: offset,
+                        expected: *total_length,
+                    })
                 } else {
+                    if made_progress {
+                        self.no_progress_polls = 0;
+                    } else {
+                        bump_no_progress(&mut self.no_progress_polls)?;
+                    }
                     let chunk_len = (total_length - offset).min(self.max_buffer_size);
                     let hr_bytes = hr_bytes.clone();
                     let hr_uuid = *hr_uuid;
@@ -318,6 +401,156 @@ impl ReaderApduHandoverDriver {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// Drives a negotiated handover through the Hr write ack (transcript from
+    /// the multipaz session), leaving the driver waiting for the Hs length.
+    /// Includes one "Te not ready" poll to cover the Te-length zero path.
+    fn drive_negotiated_to_hr_ack() -> ReaderApduHandoverDriver {
+        let mut driver = ReaderApduHandoverDriver::new().0;
+        driver.process_rapdu(&[0x90, 0x00]).expect("aid select ack");
+        driver.process_rapdu(&[0x90, 0x00]).expect("cc select ack");
+        driver
+            .process_rapdu(&[
+                0x00, 0x0F, 0x20, 0x7F, 0xFF, 0x7F, 0xFF, 0x04, 0x06, 0xE1, 0x04, 0x7F, 0xFF, 0x00,
+                0x00, 0x90, 0x00,
+            ])
+            .expect("cc read");
+        driver
+            .process_rapdu(&[0x90, 0x00])
+            .expect("ndef select ack");
+        driver
+            .process_rapdu(&[0x00, 0x1F, 0x90, 0x00])
+            .expect("ndef length");
+        driver
+            .process_rapdu(&[
+                0xD1, 0x02, 0x1A, 0x54, 0x70, 0x10, 0x13, 0x75, 0x72, 0x6E, 0x3A, 0x6E, 0x66, 0x63,
+                0x3A, 0x73, 0x6E, 0x3A, 0x68, 0x61, 0x6E, 0x64, 0x6F, 0x76, 0x65, 0x72, 0x00, 0x00,
+                0x0F, 0xFF, 0xFF, 0x90, 0x00,
+            ])
+            .expect("tp record");
+        driver.process_rapdu(&[0x90, 0x00]).expect("ts write ack");
+        // Te not ready yet → driver must re-read the length
+        let res = driver
+            .process_rapdu(&[0x00, 0x00, 0x90, 0x00])
+            .expect("te length poll");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x00, 0x02]);
+            }
+            _ => panic!("expected Te length re-read, got {res:?}"),
+        }
+        driver
+            .process_rapdu(&[0x00, 0x06, 0x90, 0x00])
+            .expect("te length");
+        driver
+            .process_rapdu(&[0xD1, 0x02, 0x01, 0x54, 0x65, 0x00, 0x90, 0x00])
+            .expect("te data");
+        driver.process_rapdu(&[0x90, 0x00]).expect("hr write ack");
+        driver
+    }
+
+    /// Apple Wallet acks the Hr while its Handover Select is still being
+    /// prepared, returning an empty NDEF message (length 0). The driver must
+    /// poll the length instead of entering the data state with
+    /// `total_length: 0` (which previously looped until the NFC link died).
+    #[test_log::test]
+    fn negotiated_hs_not_ready_polls_then_succeeds() {
+        let mut driver = drive_negotiated_to_hr_ack();
+        for _ in 0..3 {
+            let res = driver
+                .process_rapdu(&[0x00, 0x00, 0x90, 0x00])
+                .expect("hs length poll");
+            match res {
+                ReaderApduProgress::InProgress(bytes) => {
+                    assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x00, 0x02]);
+                }
+                _ => panic!("expected Hs length re-read, got {res:?}"),
+            }
+        }
+        // Hs ready (186 bytes, multipaz transcript) → read data → Done
+        let res = driver
+            .process_rapdu(&[0x00, 0xBA, 0x90, 0x00])
+            .expect("hs length");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x02, 0xBA]);
+            }
+            _ => panic!("expected READ BINARY for Hs data, got {res:?}"),
+        }
+        let res = driver
+            .process_rapdu(&[
+                0x91, 0x02, 0x0F, 0x48, 0x73, 0x15, 0xD1, 0x02, 0x09, 0x61, 0x63, 0x01, 0x01, 0x30,
+                0x01, 0x04, 0x6D, 0x64, 0x6F, 0x63, 0x1C, 0x1E, 0x58, 0x04, 0x69, 0x73, 0x6F, 0x2E,
+                0x6F, 0x72, 0x67, 0x3A, 0x31, 0x38, 0x30, 0x31, 0x33, 0x3A, 0x64, 0x65, 0x76, 0x69,
+                0x63, 0x65, 0x65, 0x6E, 0x67, 0x61, 0x67, 0x65, 0x6D, 0x65, 0x6E, 0x74, 0x6D, 0x64,
+                0x6F, 0x63, 0xA2, 0x00, 0x63, 0x31, 0x2E, 0x30, 0x01, 0x82, 0x01, 0xD8, 0x18, 0x58,
+                0x4B, 0xA4, 0x01, 0x02, 0x20, 0x01, 0x21, 0x58, 0x20, 0x5E, 0xB2, 0x16, 0xAC, 0x43,
+                0x77, 0xD2, 0x9E, 0xA6, 0x1C, 0xF1, 0x3E, 0x71, 0x24, 0x7A, 0x45, 0xC2, 0xE5, 0x60,
+                0xF0, 0x1E, 0xCC, 0x66, 0x22, 0x1E, 0x2D, 0xB7, 0x1C, 0x02, 0xD9, 0x75, 0x05, 0x22,
+                0x58, 0x20, 0x07, 0x29, 0x3E, 0x94, 0x76, 0x00, 0xB0, 0x34, 0x39, 0x8B, 0xBA, 0xE0,
+                0x12, 0xF3, 0xF9, 0xDF, 0x49, 0x69, 0x2B, 0x73, 0x77, 0xE8, 0x8A, 0xDF, 0x46, 0x53,
+                0x24, 0x78, 0xB2, 0x97, 0xE8, 0x64, 0x5A, 0x20, 0x03, 0x01, 0x61, 0x70, 0x70, 0x6C,
+                0x69, 0x63, 0x61, 0x74, 0x69, 0x6F, 0x6E, 0x2F, 0x76, 0x6E, 0x64, 0x2E, 0x62, 0x6C,
+                0x75, 0x65, 0x74, 0x6F, 0x6F, 0x74, 0x68, 0x2E, 0x6C, 0x65, 0x2E, 0x6F, 0x6F, 0x62,
+                0x30, 0x02, 0x1C, 0x01, 0x90, 0x00,
+            ])
+            .expect("hs data");
+        assert!(matches!(res, ReaderApduProgress::Done(_)));
+    }
+
+    /// A holder that never produces the Hs must yield an error once the poll
+    /// budget is exhausted instead of looping forever.
+    #[test_log::test]
+    fn negotiated_hs_never_ready_errors_out() {
+        let mut driver = drive_negotiated_to_hr_ack();
+        for i in 0..MAX_NO_PROGRESS_POLLS {
+            let res = driver
+                .process_rapdu(&[0x00, 0x00, 0x90, 0x00])
+                .unwrap_or_else(|e| panic!("poll {i} should still be in budget: {e}"));
+            assert!(matches!(res, ReaderApduProgress::InProgress(_)));
+        }
+        let res = driver.process_rapdu(&[0x00, 0x00, 0x90, 0x00]);
+        assert!(matches!(
+            res,
+            Err(ReaderApduError::ResponsePollLimitExceeded(_))
+        ));
+    }
+
+    /// The initial NDEF read can also race the holder's HCE service; length 0
+    /// must poll rather than enter the data state.
+    #[test_log::test]
+    fn initial_ndef_not_ready_polls() {
+        let mut driver = ReaderApduHandoverDriver::new().0;
+        driver.process_rapdu(&[0x90, 0x00]).expect("aid select ack");
+        driver.process_rapdu(&[0x90, 0x00]).expect("cc select ack");
+        driver
+            .process_rapdu(&[
+                0x00, 0x0F, 0x20, 0x7F, 0xFF, 0x7F, 0xFF, 0x04, 0x06, 0xE1, 0x04, 0x7F, 0xFF, 0x00,
+                0x00, 0x90, 0x00,
+            ])
+            .expect("cc read");
+        driver
+            .process_rapdu(&[0x90, 0x00])
+            .expect("ndef select ack");
+        let res = driver
+            .process_rapdu(&[0x00, 0x00, 0x90, 0x00])
+            .expect("ndef length poll");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x00, 0x02]);
+            }
+            _ => panic!("expected NDEF length re-read, got {res:?}"),
+        }
+        let res = driver
+            .process_rapdu(&[0x00, 0xE0, 0x90, 0x00])
+            .expect("ndef length");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x02, 0xE0]);
+            }
+            _ => panic!("expected READ BINARY for NDEF data, got {res:?}"),
+        }
+    }
 
     #[test]
     /// Transcript from a manual test

--- a/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
@@ -87,10 +87,10 @@ impl ReaderApduHandoverDriver {
     pub fn new() -> (Self, Vec<u8>) {
         let self_ = Self {
             state: ReaderHandoverState::WaitingForAidResponse,
-            // hardcoding the buffer size to the standard short APDU limit for now, but in the
-            // future we might have to make it configurable if we see either the need to use
-            // extended APDUs or encounter discrepancies between platforms.
-            max_buffer_size: 264,
+            // Short-APDU Le is a single byte, so 255 is the largest chunk that
+            // ReadBinary can request without truncating (264 used to encode as
+            // Le=8). Extended APDUs would allow more if ever needed.
+            max_buffer_size: 255,
             no_progress_polls: 0,
         };
         let apdu = Apdu::SelectAid {
@@ -223,8 +223,10 @@ impl ReaderApduHandoverDriver {
                     } else {
                         self.max_buffer_size
                     };
+                    // `offset` is within the NDEF message; the file itself
+                    // starts with the 2-byte NLEN field.
                     let apdu = Apdu::ReadBinary {
-                        slice: offset..offset + chunk_len,
+                        slice: 2 + offset..2 + offset + chunk_len,
                     };
                     self.state = ReaderHandoverState::WaitingForNdefReadResponseData {
                         total_length: *total_length,
@@ -549,6 +551,44 @@ mod test {
                 assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x02, 0xE0]);
             }
             _ => panic!("expected READ BINARY for NDEF data, got {res:?}"),
+        }
+    }
+
+    /// NDEF messages larger than one APDU chunk must be read at the file
+    /// offset (NLEN field + message offset), and each chunk's Le must fit in
+    /// a short APDU.
+    #[test_log::test]
+    fn static_ndef_multi_chunk_read() {
+        let mut driver = ReaderApduHandoverDriver::new().0;
+        driver.process_rapdu(&[0x90, 0x00]).expect("aid select ack");
+        driver.process_rapdu(&[0x90, 0x00]).expect("cc select ack");
+        driver
+            .process_rapdu(&[
+                0x00, 0x0F, 0x20, 0x7F, 0xFF, 0x7F, 0xFF, 0x04, 0x06, 0xE1, 0x04, 0x7F, 0xFF, 0x00,
+                0x00, 0x90, 0x00,
+            ])
+            .expect("cc read");
+        driver
+            .process_rapdu(&[0x90, 0x00])
+            .expect("ndef select ack");
+        // NLEN = 300 → first chunk: 255 bytes at file offset 2
+        let res = driver
+            .process_rapdu(&[0x01, 0x2C, 0x90, 0x00])
+            .expect("ndef length");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x00, 0x02, 0xFF]);
+            }
+            _ => panic!("expected READ BINARY for first chunk, got {res:?}"),
+        }
+        // 255 bytes received → second chunk: 45 bytes at file offset 257
+        let chunk = [vec![0xAA; 255], vec![0x90, 0x00]].concat();
+        let res = driver.process_rapdu(&chunk).expect("first chunk");
+        match res {
+            ReaderApduProgress::InProgress(bytes) => {
+                assert_eq!(bytes, [0x00, 0xB0, 0x01, 0x01, 0x2D]);
+            }
+            _ => panic!("expected READ BINARY for second chunk, got {res:?}"),
         }
     }
 

--- a/src/definitions/device_engagement/nfc/ble.rs
+++ b/src/definitions/device_engagement/nfc/ble.rs
@@ -43,7 +43,7 @@ impl<'a> AdPacket<'a> {
             cursor += len;
 
             Some(Self {
-                kind: ad_type.into(),
+                kind: KnownOrRaw::from_raw(ad_type),
                 data: ad_data,
             })
         })

--- a/src/definitions/device_engagement/nfc/ndef_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/ndef_handover_reader.rs
@@ -54,14 +54,32 @@ pub enum ReaderHandoverState {
     Done,
 }
 
-/// Returns the TNEP service URI if the NDEF data contains a Well-Known "Tp" (Service Parameter) record.
-pub(super) fn detect_tp_service(data: &[u8]) -> Option<String> {
+/// Default TNEP minimum waiting time when the Tp record omits the WT field.
+pub(super) const DEFAULT_T_WAIT_MS: u32 = 8;
+
+/// TNEP service parameters from a "Tp" (Service Parameter) record.
+pub(super) struct TpServiceParams {
+    pub service_name: String,
+    /// Minimum waiting time before (re-)reading the service's response.
+    pub t_wait_ms: u32,
+}
+
+/// TNEP §4.1.6: T_wait = 2^(WT/4 − 1) ms. Integer approximation, clamped to
+/// [1, 1000] ms so a hostile WT can't stall the reader for ~28 s.
+pub(super) fn tnep_t_wait_ms(wt: u8) -> u32 {
+    (((1u64 << (wt as u64 / 4)) + 1) / 2).clamp(1, 1000) as u32
+}
+
+/// Returns the TNEP service parameters if the NDEF data contains a Well-Known
+/// "Tp" (Service Parameter) record.
+pub(super) fn detect_tp_service(data: &[u8]) -> Option<TpServiceParams> {
     let message = ndef_rs::NdefMessage::decode(data).ok()?;
     let record = message
         .records()
         .iter()
         .find(|r| r.record_type() == b"Tp" && r.tnf() == TNF::WellKnown)?;
-    // Tp payload: [tnep_version (1)][service_name_length (1)][service_name]...
+    // Tp payload: [tnep_version (1)][service_name_length (1)][service_name]
+    //             [comm_mode (1)][WT (1)][N_WAIT (1)][max_msg_size (2)]
     let payload = record.payload();
     if payload.len() < 2 {
         return None;
@@ -70,7 +88,15 @@ pub(super) fn detect_tp_service(data: &[u8]) -> Option<String> {
     if payload.len() < 2 + name_len {
         return None;
     }
-    String::from_utf8(payload[2..2 + name_len].to_vec()).ok()
+    let service_name = String::from_utf8(payload[2..2 + name_len].to_vec()).ok()?;
+    let t_wait_ms = payload
+        .get(2 + name_len + 1)
+        .map(|wt| tnep_t_wait_ms(*wt))
+        .unwrap_or(DEFAULT_T_WAIT_MS);
+    Some(TpServiceParams {
+        service_name,
+        t_wait_ms,
+    })
 }
 
 /// Builds the TNEP Service Select (Ts) NDEF message for the given service URI.
@@ -444,8 +470,18 @@ mod test {
             0x3A, 0x73, 0x6E, 0x3A, 0x68, 0x61, 0x6E, 0x64, 0x6F, 0x76, 0x65, 0x72, 0x00, 0x00,
             0x0F, 0xFF, 0xFF,
         ];
-        let service = detect_tp_service(tp_rapdu);
-        assert_eq!(service.as_deref(), Some(TNEP_HANDOVER_SERVICE_URI));
+        let service = detect_tp_service(tp_rapdu).expect("should detect Tp service");
+        assert_eq!(service.service_name, TNEP_HANDOVER_SERVICE_URI);
+        // multipaz advertises WT=0
+        assert_eq!(service.t_wait_ms, 1);
+    }
+
+    #[test]
+    fn tnep_t_wait_conversion() {
+        assert_eq!(tnep_t_wait_ms(0x00), 1); // 0.5 ms rounded up
+        assert_eq!(tnep_t_wait_ms(0x10), 8); // Google Wallet
+        assert_eq!(tnep_t_wait_ms(0x14), 16); // Apple Wallet
+        assert_eq!(tnep_t_wait_ms(63), 1000); // clamped
     }
 
     #[test]

--- a/src/definitions/device_engagement/nfc/ndef_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/ndef_handover_reader.rs
@@ -67,7 +67,7 @@ pub(super) struct TpServiceParams {
 /// TNEP §4.1.6: T_wait = 2^(WT/4 − 1) ms. Integer approximation, clamped to
 /// [1, 1000] ms so a hostile WT can't stall the reader for ~28 s.
 pub(super) fn tnep_t_wait_ms(wt: u8) -> u32 {
-    (((1u64 << (wt as u64 / 4)) + 1) / 2).clamp(1, 1000) as u32
+    (1u64 << (wt as u64 / 4)).div_ceil(2).clamp(1, 1000) as u32
 }
 
 /// Returns the TNEP service parameters if the NDEF data contains a Well-Known

--- a/src/definitions/device_engagement/nfc/util.rs
+++ b/src/definitions/device_engagement/nfc/util.rs
@@ -17,8 +17,14 @@ impl<TU: Clone, TK: IntoRaw<TU>> IntoRaw<TU> for KnownOrRaw<TU, TK> {
     }
 }
 
-impl<TU: Clone, TK: IntoRaw<TU> + TryFrom<TU>> From<TU> for KnownOrRaw<TU, TK> {
-    fn from(raw: TU) -> Self {
+impl<TU: Clone, TK: IntoRaw<TU> + TryFrom<TU>> KnownOrRaw<TU, TK> {
+    /// Classify a raw value as [KnownOrRaw::Known] when it maps to a `TK`,
+    /// keeping it [KnownOrRaw::Unknown] otherwise.
+    ///
+    /// Inherent rather than a blanket `From<TU>` impl: a fully generic
+    /// `From` collides with foreign `impl From<X> for <X as Trait>::Type`
+    /// impls under coherence (`time` 0.3.48 introduced one).
+    pub fn from_raw(raw: TU) -> Self {
         match TK::try_from(raw.clone()) {
             Ok(known) => KnownOrRaw::Known(known),
             Err(_) => KnownOrRaw::Unknown(raw),

--- a/src/definitions/issuer_signed_dehydrated.rs
+++ b/src/definitions/issuer_signed_dehydrated.rs
@@ -223,8 +223,8 @@ mod test {
             .namespaces
             .clone()
             .expect("namespaces does not exist")
-            .iter()
-            .flat_map(|(_, value)| value.iter())
+            .values()
+            .flat_map(|value| value.iter())
             .all(|item| {
                 item.inner.element_value.is_none()
                     || item.inner.element_value == Some(ciborium::Value::Null)
@@ -242,8 +242,8 @@ mod test {
         let has_data = issuer_signed
             .namespaces
             .expect("namespaces does not exist")
-            .iter()
-            .flat_map(|(_, value)| value.iter())
+            .values()
+            .flat_map(|value| value.iter())
             .any(|item| item.inner.element_value != ciborium::Value::Null);
 
         assert!(has_data)


### PR DESCRIPTION
## Summary

Reading an mDL from Apple Wallet over negotiated NFC handover hung in an infinite APDU loop until the NFC link died (`IOException: Transceive failed` after ~1100 rounds on device). Samsung Wallet (static handover) and Google Wallet / multipaz (negotiated, but with their Handover Select ready immediately) were unaffected, which is why the existing transcript tests missed it. Root-caused from a full APDU log of a real Pixel-reader → Apple-Wallet-holder session; that transcript is now a pair of regression tests.

Three commits, one bug chain plus two adjacent bugs the investigation surfaced:

### 1. Poll on empty NDEF message instead of looping (the hang)

TNEP signals "response not ready yet" with an **empty NDEF message** (NLEN = 0) and expects the reader to re-read until the message appears. Apple Wallet acks the Hr write before its Handover Select is prepared, so the next length read legitimately returns `[0x00, 0x00]`.

The driver instead treated 0 as a real length and entered `WaitingForHsData { total_length: 0 }`, where the exit condition `offset == total_length` could never hold once the holder returned any bytes: `total_length - offset` underflowed (panic in debug, wrap in release), and in release the wrapped chunk size kept the loop issuing `ReadBinary`s forever.

All three NDEF length reads (initial message, Te, Hs) now re-read on NLEN = 0, bounded by a shared no-progress budget (`MAX_NO_PROGRESS_POLLS = 100`; one poll costs one NFC round trip ≥ ~10 ms, which already exceeds TNEP's minimum waiting times — WT=0 → 0.5 ms, Apple's WT=0x14 → 16 ms — so no sleeping is needed and the sans-IO `ReaderApduProgress` API is unchanged). Data-state reads now also error on a holder returning more bytes than advertised, and count empty payloads against the same budget.

Verified against the TNEP flow: the existing `Ts → read Te (status) → write Hr → read Hs` sequence is correct — Te only follows Service Select; the Hr response is the Hs itself, and "waiting" is expressed solely by the empty NDEF message.

### 2. Chunked NDEF reads were broken twice (latent)

- Continuation reads of a multi-chunk message started at the message offset instead of the file offset, missing the 2-byte NLEN field (the Te/Hs paths had the `2 +`; the initial-message path didn't).
- `max_buffer_size` was 264, but short-APDU Le is a single byte — `ReadBinary` encoded a 264-byte request as **Le = 8**. This is also why the device log shows every runaway read returning exactly 8 zero bytes. Now 255.

Neither had surfaced because every existing transcript fits in one chunk.

### 3. Apple's DeviceEngagement is version "1.1" (would have failed at parse next)

Apple emits an ISO 18013-5 Second Edition DeviceEngagement (`{0: "1.1", …, 5: [], 6: {3: true, 4: true}}`). The deserializer hard-rejected anything but `"1.0"`, so with the loop fixed the handover would still have failed at Hs parse. 1.1 only adds fields a reader may ignore; the deserializer now accepts `"1.0" | "1.1"` and preserves the original version string instead of rewriting it to "1.0". Unknown integer keys were already ignored.

## Tests

- `apple_wallet_hs_length_zero_does_not_loop_forever` — real-device transcript through Hr ack, then NLEN = 0 followed by the 8-zero-byte responses observed on device; asserts the driver resolves (Done or Err) within a bounded number of steps. Fails on the previous code in both build profiles (debug: subtract-with-overflow panic; release: unbounded loop).
- `apple_wallet_hs_polls_then_done` — the success path: NLEN = 0 polls, then the real length (0x00C2) and Apple's actual 194-byte Hs → `Done`, asserting `device_engagement.version == "1.1"`.
- `negotiated_hs_not_ready_polls_then_succeeds`, `negotiated_hs_never_ready_errors_out`, `initial_ndef_not_ready_polls` — synthetic coverage for the poll budget and the Te / initial-message zero-length paths.
- `static_ndef_multi_chunk_read` — multi-chunk read offsets and Le encoding.

`cargo test --lib`: 151 passed / 0 failed (all existing transcripts — multipaz static & negotiated, Samsung, Google — unchanged). `cargo clippy` with `-Dwarnings` and `cargo fmt --check` clean.

## Notes for reviewers

- `MAX_NO_PROGRESS_POLLS = 100` (~1–5 s depending on RTT) is a judgement call; if real-device testing shows Apple regularly needing more, it's a one-line bump.
- Downstream: sprucekit-mobile pins isomdl by rev; after merge it needs a rev bump + regenerated Swift bindings to pick this up.