### PR TITLE
Preserve raw DeviceEngagement bytes in NFC SessionTranscript (fixes Apple Wallet decryption)

### DIFF
--- a/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/apdu_handover_reader.rs
@@ -730,7 +730,43 @@ mod test {
         let ReaderApduProgress::Done(carrier_info) = res else {
             panic!("expected Done, got {res:?}");
         };
-        assert_eq!(carrier_info.device_engagement.version, "1.1");
+        assert_eq!(carrier_info.device_engagement.as_ref().version, "1.1");
+    }
+
+    /// Regression for the Apple Wallet "could not decrypt the response" failure: the
+    /// SessionTranscript's `DeviceEngagementBytes` must reuse the holder's *exact*
+    /// `deviceengagement` record bytes. Apple's DeviceEngagement is a four-key map (ISO 18013-5
+    /// Second Edition keys 5 and 6 alongside 0 and 1); re-serializing the parsed struct dropped
+    /// keys 5/6, so the reader hashed a different SessionTranscript than the holder and derived a
+    /// mismatched AES-GCM session key.
+    #[test_log::test]
+    fn apple_hs_preserves_raw_device_engagement_bytes() {
+        // The `deviceengagement` external record payload sits at the tail of APPLE_HS_NDEF.
+        let raw_de: &[u8] = &APPLE_HS_NDEF[98..];
+        assert_eq!(raw_de.len(), 96);
+        assert_eq!(raw_de[0], 0xA4, "holder DE is a 4-key map {{0,1,5,6}}");
+        // Keys 5 (`05 80`) and 6 (`06 A2 03 F5 04 F5`) close out the map.
+        assert_eq!(
+            raw_de[88..],
+            [0x05, 0x80, 0x06, 0xA2, 0x03, 0xF5, 0x04, 0xF5]
+        );
+
+        let carrier_info =
+            ReaderNegotiatedCarrierInfo::parse_hs_ndef_message(APPLE_HS_NDEF, uuid::Uuid::nil())
+                .expect("parse Apple Hs");
+
+        // The Tag24 fed into the SessionTranscript carries the raw bytes verbatim.
+        assert_eq!(
+            carrier_info.device_engagement.inner_bytes.as_slice(),
+            raw_de,
+            "DeviceEngagementBytes must match the holder's raw DE encoding"
+        );
+
+        // Guard the root cause: re-encoding the parsed struct silently drops keys 5/6,
+        // collapsing the map to two keys — which is what broke decryption.
+        let reencoded = crate::cbor::to_vec(carrier_info.device_engagement.as_ref()).unwrap();
+        assert_eq!(reencoded[0], 0xA2, "re-encoded DE collapses to a 2-key map");
+        assert_ne!(reencoded.as_slice(), raw_de);
     }
 
     /// A holder advertising a small MLe in its CC file must be read in

--- a/src/definitions/device_engagement/nfc/ndef_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/ndef_handover_reader.rs
@@ -7,16 +7,13 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 use uuid::Uuid;
 
-use crate::{
-    cbor,
-    definitions::{
-        device_engagement::nfc::{
-            ble::ad_packet::KnownType,
-            ndef_handover::{LeRole, RawPayload, RecordType},
-        },
-        helpers::ByteStr,
-        DeviceEngagement,
+use crate::definitions::{
+    device_engagement::nfc::{
+        ble::ad_packet::KnownType,
+        ndef_handover::{LeRole, RawPayload, RecordType},
     },
+    helpers::{ByteStr, Tag24},
+    DeviceEngagement,
 };
 
 #[derive(Debug, Clone)]
@@ -255,7 +252,11 @@ pub(super) fn parse_te_ndef(data: &[u8]) -> Result<()> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReaderNegotiatedCarrierInfo {
-    pub device_engagement: DeviceEngagement,
+    /// Held as [`Tag24`] built from the *raw* `deviceengagement` NDEF record bytes so the
+    /// SessionTranscript reuses the holder's exact CBOR encoding. Re-serializing a parsed
+    /// [`DeviceEngagement`] would drop ISO 18013-5 Second Edition keys 5/6 (which the struct has
+    /// no fields for), diverging from what the holder hashes and breaking session-key derivation.
+    pub device_engagement: Tag24<DeviceEngagement>,
     pub uuid: Uuid,
     pub holder_le_role: LeRole,
     /// Handover Select Message
@@ -323,8 +324,9 @@ impl ReaderNegotiatedCarrierInfo {
             .find(|r| r.record_type() == b"application/vnd.bluetooth.le.oob")
             .ok_or_else(|| anyhow!("Missing BLE OOB carrier capability NDEF record"))?;
 
-        let device_engagement = cbor::from_slice(device_engagement_record.payload())
-            .context("Could not parse device engagement CBOR bytes")?;
+        let device_engagement =
+            Tag24::<DeviceEngagement>::from_bytes(device_engagement_record.payload().to_vec())
+                .context("Could not parse device engagement CBOR bytes")?;
 
         let (holder_le_role, uuid, ble_device_address) =
             parse_cc_record(cc_record).context("failed to parse cc record")?;

--- a/src/definitions/device_engagement/nfc/ndef_handover_reader.rs
+++ b/src/definitions/device_engagement/nfc/ndef_handover_reader.rs
@@ -252,10 +252,20 @@ pub(super) fn parse_te_ndef(data: &[u8]) -> Result<()> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReaderNegotiatedCarrierInfo {
-    /// Held as [`Tag24`] built from the *raw* `deviceengagement` NDEF record bytes so the
-    /// SessionTranscript reuses the holder's exact CBOR encoding. Re-serializing a parsed
-    /// [`DeviceEngagement`] would drop ISO 18013-5 Second Edition keys 5/6 (which the struct has
-    /// no fields for), diverging from what the holder hashes and breaking session-key derivation.
+    /// Held as [`Tag24`] built from the *raw* `deviceengagement` NDEF record bytes — not by
+    /// re-encoding a parsed [`DeviceEngagement`] — so the SessionTranscript reuses the holder's
+    /// exact CBOR encoding, which is what the holder hashes when deriving the session keys.
+    ///
+    /// Re-encoding cannot be made byte-identical to the holder in general, so modeling the
+    /// missing fields on [`DeviceEngagement`] would not be a complete fix:
+    /// - The DeviceEngagement CDDL has open extension points (`* uint => RFU`, `* nint => Ext`)
+    ///   that no struct can enumerate. ISO 18013-5 Second Edition keys 5/6 (sent by Apple Wallet)
+    ///   are merely the case seen here; the next holder that includes an Ext key would re-break
+    ///   decryption.
+    /// - CBOR is not canonical by default (map-key ordering, integer width, definite vs.
+    ///   indefinite length), so a conformant holder may legitimately encode differently than this
+    ///   crate's `From<DeviceEngagement>` impl, and re-encoding would normalize it into a
+    ///   divergent byte string.
     pub device_engagement: Tag24<DeviceEngagement>,
     pub uuid: Uuid,
     pub holder_le_role: LeRole,

--- a/src/presentation/reader.rs
+++ b/src/presentation/reader.rs
@@ -306,6 +306,12 @@ impl SessionManager {
         let session_transcript_bytes = Tag24::new(session_transcript.clone())
             .context("failed to encode session transcript")?;
 
+        tracing::debug!(
+            "reader SessionTranscript ({} bytes): {:?}",
+            session_transcript_bytes.inner_bytes.len(),
+            session_transcript_bytes.inner_bytes.as_slice()
+        );
+
         //derive session keys
         let sk_reader = derive_session_key(&shared_secret, &session_transcript_bytes, true)
             .context("failed to derive reader session key")?
@@ -422,6 +428,12 @@ impl SessionManager {
 
     fn decrypt_response(&mut self, response: &[u8]) -> Result<DeviceResponse, Error> {
         let session_data: SessionData = cbor::from_slice(response)?;
+        tracing::debug!(
+            "decrypt_response: {} response bytes, data_present={}, status={:?}",
+            response.len(),
+            session_data.data.is_some(),
+            session_data.status.as_ref()
+        );
         let encrypted_response = match session_data.data {
             None => return Err(Error::HolderError),
             Some(r) => r,
@@ -432,6 +444,11 @@ impl SessionManager {
             &mut self.device_message_counter,
         )
         .map_err(|_e| Error::DecryptionError)?;
+        tracing::debug!(
+            "decrypt_response: decrypted OK, {} plaintext bytes (from {} encrypted)",
+            decrypted_response.len(),
+            encrypted_response.as_ref().len()
+        );
         let device_response: DeviceResponse = cbor::from_slice(&decrypted_response)?;
         Ok(device_response)
     }

--- a/src/presentation/reader.rs
+++ b/src/presentation/reader.rs
@@ -212,8 +212,7 @@ impl SessionManager {
             holder_peripheral_server_modes,
         ) = match handover {
             Handover::NFC(carrier_info) => {
-                let device_engagement_bytes = Tag24::new(carrier_info.device_engagement)
-                    .context("Failed to build tag24 device engagement")?;
+                let device_engagement_bytes = carrier_info.device_engagement;
                 let le_role = Some(carrier_info.holder_le_role);
                 let uuid = carrier_info.uuid;
                 let central_client_modes: Vec<_> = device_engagement_bytes


### PR DESCRIPTION
Re-serializing the parsed DeviceEngagement dropped ISO 18013-5 2nd-ed keys 5/6 (0xA4 map-of-4 → 0xA2 map-of-2), diverging from the holder's hashed transcript → AES-GCM decryption failure vs Apple Wallet. Fix: hold DE as Tag24 from the raw NDEF record bytes (Tag24::from_bytes). 2nd commit = temporary reader diagnostics for QA. Regression test included; local CI green.