### PR TITLE
Fix digest verification

### DIFF
--- a/src/definitions/mso.rs
+++ b/src/definitions/mso.rs
@@ -33,6 +33,7 @@
 //!   and `SHA-512`.
 use crate::definitions::{helpers::ByteStr, DeviceKeyInfo, ValidityInfo};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256, Sha384, Sha512};
 use std::collections::BTreeMap;
 
 /// DigestId is a unsigned integer between `0` and `(2^31 - 1)` inclusive.
@@ -78,6 +79,21 @@ pub enum DigestAlgorithm {
 impl DigestId {
     pub fn new(i: i32) -> DigestId {
         DigestId(if i.is_negative() { -i } else { i })
+    }
+}
+
+impl DigestAlgorithm {
+    /// Compute the digest of `data` using this algorithm.
+    ///
+    /// Both issuance (when building [Mso::value_digests]) and reader-side
+    /// verification (when checking disclosed items against those digests) go
+    /// through this single function, so the two sides cannot drift apart.
+    pub fn digest(&self, data: &[u8]) -> Vec<u8> {
+        match self {
+            DigestAlgorithm::SHA256 => Sha256::digest(data).to_vec(),
+            DigestAlgorithm::SHA384 => Sha384::digest(data).to_vec(),
+            DigestAlgorithm::SHA512 => Sha512::digest(data).to_vec(),
+        }
     }
 }
 

--- a/src/issuance/mdoc.rs
+++ b/src/issuance/mdoc.rs
@@ -6,7 +6,6 @@ use coset::iana::Algorithm;
 use coset::{CoseSign1, Label};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256, Sha384, Sha512};
 use signature::{SignatureEncoding, Signer};
 
 use crate::cose::sign1::PreparedCoseSign1;
@@ -433,11 +432,7 @@ fn digest_namespace(
         .chain(random_digests)
         .map(|result| {
             let (digest_id, bytes) = result?;
-            let digest = match digest_algorithm {
-                DigestAlgorithm::SHA256 => Sha256::digest(bytes).to_vec(),
-                DigestAlgorithm::SHA384 => Sha384::digest(bytes).to_vec(),
-                DigestAlgorithm::SHA512 => Sha512::digest(bytes).to_vec(),
-            };
+            let digest = digest_algorithm.digest(&bytes);
             Ok((digest_id, digest.into()))
         })
         .collect()

--- a/src/presentation/authentication/mdoc.rs
+++ b/src/presentation/authentication/mdoc.rs
@@ -3,6 +3,7 @@ use crate::cose::mac0::VerificationResult as Mac0VerificationResult;
 use crate::cose::sign1::VerificationResult;
 use crate::definitions::device_response::Document;
 use crate::definitions::issuer_signed;
+use crate::definitions::issuer_signed::IssuerNamespaces;
 use crate::definitions::session::{derive_e_mac_key, get_shared_secret, SessionTranscript};
 use crate::definitions::x509::{SupportedCurve, X5Chain};
 use crate::definitions::DeviceAuth;
@@ -54,7 +55,65 @@ pub fn issuer_authentication(x5chain: X5Chain, issuer_signed: &IssuerSigned) -> 
 
     verification_result
         .into_result()
-        .map_err(Error::IssuerAuthentication)
+        .map_err(Error::IssuerAuthentication)?;
+
+    // The signature over the MSO is valid. Per ISO/IEC 18013-5 §9.1.2.5, issuer
+    // data authentication also requires binding the disclosed data element values
+    // to the digests committed to in the MSO: recompute the digest of every
+    // returned `IssuerSignedItem` and check it against `ValueDigests`. Without this
+    // a holder could alter element values while reusing the genuine issuer signature.
+    if let Some(namespaces) = &issuer_signed.namespaces {
+        let mso_bytes = issuer_signed
+            .issuer_auth
+            .payload
+            .as_ref()
+            .ok_or(Error::DetachedIssuerAuth)?;
+        let mso = cbor::from_slice::<Tag24<Mso>>(mso_bytes)
+            .map_err(|_| Error::MSOParsing)?
+            .into_inner();
+        verify_value_digests(&mso, namespaces)?;
+    }
+
+    Ok(())
+}
+
+/// Recompute the digest of every disclosed [`IssuerSignedItem`] and verify it
+/// matches the corresponding entry in the MSO's `value_digests`.
+///
+/// Only the *disclosed* items are checked (each must have a matching digest);
+/// the MSO legitimately carries digests for undisclosed items and decoys, so we
+/// do not require the reverse mapping — that would break selective disclosure.
+///
+/// [`IssuerSignedItem`]: crate::definitions::issuer_signed::IssuerSignedItem
+fn verify_value_digests(mso: &Mso, namespaces: &IssuerNamespaces) -> Result<(), Error> {
+    for (namespace, items) in namespaces.iter() {
+        let expected_digests = mso.value_digests.get(namespace).ok_or_else(|| {
+            Error::IssuerDigestMismatch(format!(
+                "MSO contains no value digests for namespace {namespace}"
+            ))
+        })?;
+
+        for item in items.iter() {
+            let digest_id = item.as_ref().digest_id;
+            let expected = expected_digests.get(&digest_id).ok_or_else(|| {
+                Error::IssuerDigestMismatch(format!(
+                    "MSO has no digest for digestID {digest_id:?} in namespace {namespace}"
+                ))
+            })?;
+
+            let item_bytes = cbor::to_vec(item)?;
+            let computed = mso.digest_algorithm.digest(&item_bytes);
+
+            if computed.as_slice() != expected.as_ref() {
+                return Err(Error::IssuerDigestMismatch(format!(
+                    "digest mismatch for element {:?} (digestID {digest_id:?}) in namespace {namespace}",
+                    item.as_ref().element_identifier
+                )));
+            }
+        }
+    }
+
+    Ok(())
 }
 
 pub fn device_authentication<S>(
@@ -180,5 +239,186 @@ where
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::definitions::helpers::{NonEmptyMap, NonEmptyVec, Tag24};
+    use crate::definitions::issuer_signed::{IssuerNamespaces, IssuerSignedItemBytes};
+
+    const ISO_NAMESPACE: &str = "org.iso.18013.5.1";
+
+    static ISSUER_CERT: &[u8] = include_bytes!("../../../test/issuance/issuer-cert.pem");
+
+    fn issuer_x5chain() -> X5Chain {
+        X5Chain::builder()
+            .with_pem_certificate(ISSUER_CERT)
+            .unwrap()
+            .build()
+            .unwrap()
+    }
+
+    /// Rebuild `namespaces`, replacing the `element_value` of the item whose
+    /// `element_identifier == name` with `new_value`. The MSO / `issuer_auth`
+    /// signature is left completely untouched.
+    fn tamper_element(
+        namespaces: &IssuerNamespaces,
+        name: &str,
+        new_value: ciborium::Value,
+    ) -> IssuerNamespaces {
+        let mut ns_map = namespaces.clone().into_inner();
+        let items = ns_map
+            .get_mut(ISO_NAMESPACE)
+            .expect("iso namespace present");
+
+        let tampered: Vec<IssuerSignedItemBytes> = items
+            .clone()
+            .into_inner()
+            .into_iter()
+            .map(|item_bytes| {
+                let mut item = item_bytes.as_ref().clone();
+                if item.element_identifier == name {
+                    item.element_value = new_value.clone();
+                    Tag24::new(item).expect("re-encode tampered item")
+                } else {
+                    item_bytes
+                }
+            })
+            .collect();
+
+        *items = NonEmptyVec::maybe_new(tampered).expect("non-empty");
+        NonEmptyMap::maybe_new(ns_map).expect("non-empty")
+    }
+
+    fn age_over_21(namespaces: &IssuerNamespaces) -> Option<bool> {
+        namespaces
+            .get(ISO_NAMESPACE)?
+            .iter()
+            .map(|i| i.as_ref())
+            .find(|i| i.element_identifier == "age_over_21")
+            .and_then(|i| i.element_value.as_bool())
+    }
+
+    /// A holder (or a MITM on an unencrypted channel) flips `age_over_21` from
+    /// `true` to `false` while reusing the genuine issuer signature, and issuer
+    /// authentication must reject it.
+    ///
+    /// Per ISO/IEC 18013-5 §9.1.2.5 the reader MUST recompute the digest of each
+    /// returned `IssuerSignedItem` and compare it against `ValueDigests` in the MSO.
+    /// This is a regression test for the fix that added that check: without it the
+    /// tampering went undetected because the disclosed values were never bound to
+    /// the MSO digests.
+    #[test]
+    fn tampered_data_element_rejected_by_issuer_authentication() {
+        let mdoc = crate::issuance::mdoc::test::minimal_test_mdoc().expect("issue mdoc");
+        let x5chain = issuer_x5chain();
+
+        // Baseline: genuine, issuer-signed response verifies and says age_over_21 = true.
+        let genuine = IssuerSigned {
+            namespaces: Some(mdoc.namespaces.clone()),
+            issuer_auth: mdoc.issuer_auth.clone(),
+        };
+        assert_eq!(
+            age_over_21(genuine.namespaces.as_ref().unwrap()),
+            Some(true)
+        );
+        issuer_authentication(x5chain.clone(), &genuine)
+            .expect("genuine response should pass issuer authentication");
+
+        // Attack: flip age_over_21 to false, reusing the ORIGINAL issuer signature.
+        let tampered_namespaces = tamper_element(
+            &mdoc.namespaces,
+            "age_over_21",
+            ciborium::Value::Bool(false),
+        );
+        assert_eq!(age_over_21(&tampered_namespaces), Some(false));
+
+        let tampered = IssuerSigned {
+            namespaces: Some(tampered_namespaces),
+            issuer_auth: mdoc.issuer_auth.clone(),
+        };
+
+        // The digest of the tampered item no longer matches the MSO, so the
+        // value-digest check must reject the forged claim.
+        let result = issuer_authentication(x5chain, &tampered);
+        assert!(
+            matches!(result, Err(Error::IssuerDigestMismatch(_))),
+            "issuer_authentication did not reject tampered data: {result:?}"
+        );
+    }
+
+    /// Rebuild `issuer_auth` so the MSO's `value_digests` are recomputed to match
+    /// `tampered_namespaces`. This is what a more sophisticated attacker would do to
+    /// defeat the value-digest check — but rewriting the MSO changes the COSE_Sign1
+    /// payload, and the attacker cannot re-sign it without the issuer's private key.
+    fn forge_consistent_mso(
+        genuine: &IssuerSigned,
+        tampered_namespaces: IssuerNamespaces,
+    ) -> IssuerSigned {
+        let mso_bytes = genuine
+            .issuer_auth
+            .payload
+            .as_ref()
+            .expect("attached payload");
+        let mut mso = cbor::from_slice::<Tag24<Mso>>(mso_bytes)
+            .expect("parse mso")
+            .into_inner();
+
+        let alg = mso.digest_algorithm;
+        for (namespace, items) in tampered_namespaces.iter() {
+            let digests = mso
+                .value_digests
+                .get_mut(namespace)
+                .expect("namespace present in mso");
+            for item in items.iter() {
+                let item_bytes = cbor::to_vec(item).expect("encode item");
+                digests.insert(item.as_ref().digest_id, alg.digest(&item_bytes).into());
+            }
+        }
+
+        let mut issuer_auth = genuine.issuer_auth.clone();
+        issuer_auth.payload =
+            Some(cbor::to_vec(&Tag24::new(mso).expect("wrap mso")).expect("encode mso"));
+
+        IssuerSigned {
+            namespaces: Some(tampered_namespaces),
+            issuer_auth,
+        }
+    }
+
+    /// The counterpart to [`tampered_data_element_rejected_by_issuer_authentication`]: even
+    /// when the attacker also rewrites the MSO's `value_digests` so the forged element
+    /// hashes correctly (defeating the digest check in isolation), the tampering is still
+    /// caught — this time by the COSE_Sign1 signature over the MSO, which no longer
+    /// verifies against the issuer's certificate.
+    #[test]
+    fn tampered_value_and_matching_mso_digest_fails_issuer_authentication() {
+        let mdoc = crate::issuance::mdoc::test::minimal_test_mdoc().expect("issue mdoc");
+        let x5chain = issuer_x5chain();
+
+        let genuine = IssuerSigned {
+            namespaces: Some(mdoc.namespaces.clone()),
+            issuer_auth: mdoc.issuer_auth.clone(),
+        };
+
+        // Flip age_over_21 and forge a matching MSO digest for it.
+        let tampered_namespaces = tamper_element(
+            &mdoc.namespaces,
+            "age_over_21",
+            ciborium::Value::Bool(false),
+        );
+        assert_eq!(age_over_21(&tampered_namespaces), Some(false));
+
+        let forged = forge_consistent_mso(&genuine, tampered_namespaces);
+
+        // The forged MSO digests DO match the tampered items, so the value-digest check
+        // would pass. Verification must therefore fail at the signature step instead.
+        let result = issuer_authentication(x5chain, &forged);
+        assert!(
+            matches!(result, Err(Error::IssuerAuthentication(_))),
+            "expected the MSO signature check to reject the forged MSO, got: {result:?}"
+        );
     }
 }

--- a/src/presentation/reader.rs
+++ b/src/presentation/reader.rs
@@ -137,6 +137,9 @@ pub enum Error {
     IssuerAuthentication(String),
     #[error("Unable to parse issuer public key")]
     IssuerPublicKey(anyhow::Error),
+    /// A disclosed data element does not match the digest committed to in the MSO.
+    #[error("issuer-signed value digest verification failed: {0}")]
+    IssuerDigestMismatch(String),
 }
 
 impl From<CborError> for Error {


### PR DESCRIPTION
Digest verification was missing, meaning a holder could disclose invalid data and as long as they had a valid MSO it would be accepted.

This vulnerability couldn't be exploited in production as issuers only issue mDLs to known wallets that haven't been tampered with (through app attestations).