### PR TITLE
Fix MSO validity period verification

### DIFF
--- a/src/presentation/authentication/mdoc.rs
+++ b/src/presentation/authentication/mdoc.rs
@@ -21,7 +21,13 @@ use sha2::Sha256;
 use ssi_jwk::Params;
 use ssi_jwk::JWK as SsiJwk;
 
-pub fn issuer_authentication(x5chain: X5Chain, issuer_signed: &IssuerSigned) -> Result<(), Error> {
+/// Verify issuer data authentication and return the signature-verified [`Mso`].
+///
+/// This checks the COSE_Sign1 signature over the MSO and (when data elements are
+/// disclosed) binds those elements to the digests committed to in the MSO. It does
+/// **not** check the MSO's `validity_info` window — callers should feed the returned
+/// MSO to [`check_mso_validity`] against their validation time.
+pub fn issuer_authentication(x5chain: X5Chain, issuer_signed: &IssuerSigned) -> Result<Mso, Error> {
     let curve = SupportedCurve::from_certificate(x5chain.end_entity_certificate())
         .ok_or_else(|| Error::IssuerPublicKey(anyhow::anyhow!("unsupported curve")))?;
 
@@ -57,23 +63,48 @@ pub fn issuer_authentication(x5chain: X5Chain, issuer_signed: &IssuerSigned) -> 
         .into_result()
         .map_err(Error::IssuerAuthentication)?;
 
-    // The signature over the MSO is valid. Per ISO/IEC 18013-5 §9.1.2.5, issuer
-    // data authentication also requires binding the disclosed data element values
-    // to the digests committed to in the MSO: recompute the digest of every
-    // returned `IssuerSignedItem` and check it against `ValueDigests`. Without this
-    // a holder could alter element values while reusing the genuine issuer signature.
+    // The signature over the MSO is valid, so parse it (a detached payload can't be
+    // authenticated and is an error).
+    let mso_bytes = issuer_signed
+        .issuer_auth
+        .payload
+        .as_ref()
+        .ok_or(Error::DetachedIssuerAuth)?;
+    let mso = cbor::from_slice::<Tag24<Mso>>(mso_bytes)
+        .map_err(|_| Error::MSOParsing)?
+        .into_inner();
+
+    // Per ISO/IEC 18013-5 §9.1.2.5, issuer data authentication also requires binding
+    // the disclosed data element values to the digests committed to in the MSO:
+    // recompute the digest of every returned `IssuerSignedItem` and check it against
+    // `ValueDigests`. Without this a holder could alter element values while reusing
+    // the genuine issuer signature.
     if let Some(namespaces) = &issuer_signed.namespaces {
-        let mso_bytes = issuer_signed
-            .issuer_auth
-            .payload
-            .as_ref()
-            .ok_or(Error::DetachedIssuerAuth)?;
-        let mso = cbor::from_slice::<Tag24<Mso>>(mso_bytes)
-            .map_err(|_| Error::MSOParsing)?
-            .into_inner();
         verify_value_digests(&mso, namespaces)?;
     }
 
+    Ok(mso)
+}
+
+/// Check the MSO's validity window (ISO/IEC 18013-5 §9.1.2.4).
+///
+/// Returns [`Error::MsoNotYetValid`] if `at` is before `valid_from` and
+/// [`Error::MsoExpired`] if `at` is after `valid_until`. The `signed` timestamp and
+/// `expected_update` are not window bounds and are intentionally not checked here.
+///
+/// This should only be trusted for a signature-verified MSO (i.e. the value returned
+/// by [`issuer_authentication`]); the `validity_info` of an unverified MSO is
+/// attacker-controlled.
+pub fn check_mso_validity(
+    validity: &crate::definitions::ValidityInfo,
+    at: time::OffsetDateTime,
+) -> Result<(), Error> {
+    if validity.valid_from > at {
+        return Err(Error::MsoNotYetValid);
+    }
+    if validity.valid_until < at {
+        return Err(Error::MsoExpired);
+    }
     Ok(())
 }
 
@@ -420,5 +451,57 @@ mod tests {
             matches!(result, Err(Error::IssuerAuthentication(_))),
             "expected the MSO signature check to reject the forged MSO, got: {result:?}"
         );
+    }
+
+    fn validity_window(
+        from: time::OffsetDateTime,
+        until: time::OffsetDateTime,
+    ) -> crate::definitions::ValidityInfo {
+        crate::definitions::ValidityInfo {
+            signed: from,
+            valid_from: from,
+            valid_until: until,
+            expected_update: None,
+        }
+    }
+
+    /// A credential is accepted only while the validation time is within
+    /// `[valid_from, valid_until]` (ISO/IEC 18013-5 §9.1.2.4).
+    #[test]
+    fn mso_validity_window_is_enforced() {
+        let now = time::OffsetDateTime::now_utc();
+        let day = time::Duration::days(1);
+        let validity = validity_window(now - day, now + day);
+
+        // Inside the window.
+        assert!(check_mso_validity(&validity, now).is_ok());
+        assert!(check_mso_validity(&validity, now - day).is_ok());
+        assert!(check_mso_validity(&validity, now + day).is_ok());
+
+        // After `valid_until`.
+        assert!(matches!(
+            check_mso_validity(&validity, now + 2 * day),
+            Err(Error::MsoExpired)
+        ));
+
+        // Before `valid_from`.
+        assert!(matches!(
+            check_mso_validity(&validity, now - 2 * day),
+            Err(Error::MsoNotYetValid)
+        ));
+    }
+
+    /// Regression for the reported issue: an mDL whose `validUntil` is in the past
+    /// (the PoC used `2021-10-01`) must be rejected when validated at today's date.
+    #[test]
+    fn expired_mso_rejected_at_current_time() {
+        let valid_until = time::macros::datetime!(2021-10-01 0:00 UTC);
+        let valid_from = time::macros::datetime!(2020-10-01 0:00 UTC);
+        let validity = validity_window(valid_from, valid_until);
+
+        assert!(matches!(
+            check_mso_validity(&validity, time::OffsetDateTime::now_utc()),
+            Err(Error::MsoExpired)
+        ));
     }
 }

--- a/src/presentation/authentication/mdoc.rs
+++ b/src/presentation/authentication/mdoc.rs
@@ -490,18 +490,4 @@ mod tests {
             Err(Error::MsoNotYetValid)
         ));
     }
-
-    /// Regression for the reported issue: an mDL whose `validUntil` is in the past
-    /// (the PoC used `2021-10-01`) must be rejected when validated at today's date.
-    #[test]
-    fn expired_mso_rejected_at_current_time() {
-        let valid_until = time::macros::datetime!(2021-10-01 0:00 UTC);
-        let valid_from = time::macros::datetime!(2020-10-01 0:00 UTC);
-        let validity = validity_window(valid_from, valid_until);
-
-        assert!(matches!(
-            check_mso_validity(&validity, time::OffsetDateTime::now_utc()),
-            Err(Error::MsoExpired)
-        ));
-    }
 }

--- a/src/presentation/reader.rs
+++ b/src/presentation/reader.rs
@@ -21,9 +21,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use super::{authentication::ResponseAuthenticationOutcome, reader_utils::validate_response};
+use super::{
+    authentication::ResponseAuthenticationOutcome, reader_utils::validate_response_with_options,
+};
 
 use crate::definitions::x509::revocation::RevocationFetcher;
+pub use crate::definitions::x509::validation::ValidationOptions;
 
 use crate::{
     cbor::{self, CborError},
@@ -140,6 +143,12 @@ pub enum Error {
     /// A disclosed data element does not match the digest committed to in the MSO.
     #[error("issuer-signed value digest verification failed: {0}")]
     IssuerDigestMismatch(String),
+    /// The MSO's `validUntil` is in the past relative to the validation time.
+    #[error("MSO is expired")]
+    MsoExpired,
+    /// The MSO's `validFrom` is in the future relative to the validation time.
+    #[error("MSO is not yet valid")]
+    MsoNotYetValid,
 }
 
 impl From<CborError> for Error {
@@ -458,6 +467,10 @@ impl SessionManager {
 
     /// Handle a device response, validating it and checking certificate revocation.
     ///
+    /// Validity checks (certificate windows and the MSO `validityInfo` window) are
+    /// performed against the current time. Use [`Self::handle_response_with_options`]
+    /// to pin the validation time.
+    ///
     /// # Arguments
     /// * `response` - The encrypted device response
     /// * `revocation_fetcher` - Revocation fetcher for CRL checking. Use `&()` to skip revocation checks.
@@ -465,6 +478,24 @@ impl SessionManager {
         &mut self,
         response: &[u8],
         revocation_fetcher: &R,
+    ) -> ResponseAuthenticationOutcome {
+        self.handle_response_with_options(
+            response,
+            revocation_fetcher,
+            &ValidationOptions::default(),
+        )
+        .await
+    }
+
+    /// Like [`Self::handle_response`], but with explicit [`ValidationOptions`].
+    ///
+    /// The `options` control the validation time used both for certificate chain
+    /// validity checks and for the MSO `validityInfo` window check.
+    pub async fn handle_response_with_options<R: RevocationFetcher>(
+        &mut self,
+        response: &[u8],
+        revocation_fetcher: &R,
+        options: &ValidationOptions,
     ) -> ResponseAuthenticationOutcome {
         let mut validated_response = ResponseAuthenticationOutcome::default();
 
@@ -487,7 +518,7 @@ impl SessionManager {
 
         match parse(&device_response) {
             Ok((document, x5chain, namespaces)) => {
-                validate_response(
+                validate_response_with_options(
                     self.session_transcript.clone(),
                     self.trust_anchor_registry.clone(),
                     x5chain,
@@ -496,6 +527,7 @@ impl SessionManager {
                     doc_types,
                     revocation_fetcher,
                     self.e_reader_key_private,
+                    options,
                 )
                 .await
             }

--- a/src/presentation/reader_utils.rs
+++ b/src/presentation/reader_utils.rs
@@ -5,11 +5,14 @@ use serde_json::json;
 use crate::definitions::{
     device_response::Document,
     session::SessionTranscript,
-    x509::{self, revocation::RevocationFetcher, trust_anchor::TrustAnchorRegistry, X5Chain},
+    x509::{
+        self, revocation::RevocationFetcher, trust_anchor::TrustAnchorRegistry,
+        validation::ValidationOptions, X5Chain,
+    },
 };
 
 use super::authentication::{
-    mdoc::{device_authentication, issuer_authentication},
+    mdoc::{check_mso_validity, device_authentication, issuer_authentication},
     AuthenticationStatus, ResponseAuthenticationOutcome,
 };
 
@@ -27,6 +30,9 @@ use super::authentication::{
 /// * `e_reader_key_private` - The reader's ephemeral private key bytes, used for ECDH with the
 ///   device's static authentication key (SDeviceKey) when verifying COSE_Mac0 per §9.1.3.5.
 ///   Ignored when the device uses COSE_Sign1.
+///
+/// This uses the default [`ValidationOptions`] (validity checks against the current
+/// time). Use [`validate_response_with_options`] to pin the validation time.
 #[allow(clippy::too_many_arguments)]
 pub async fn validate_response<S, R>(
     session_transcript: S,
@@ -37,6 +43,41 @@ pub async fn validate_response<S, R>(
     doc_types: Vec<String>,
     revocation_fetcher: &R,
     e_reader_key_private: [u8; 32],
+) -> ResponseAuthenticationOutcome
+where
+    S: SessionTranscript + Clone,
+    R: RevocationFetcher,
+{
+    validate_response_with_options(
+        session_transcript,
+        trust_anchor_registry,
+        x5chain,
+        document,
+        namespaces,
+        doc_types,
+        revocation_fetcher,
+        e_reader_key_private,
+        &ValidationOptions::default(),
+    )
+    .await
+}
+
+/// Like [`validate_response`], but with explicit [`ValidationOptions`].
+///
+/// The `options` control the validation time used both for the certificate chain
+/// validity checks and for the MSO `validityInfo` window check, which makes both
+/// deterministic in tests.
+#[allow(clippy::too_many_arguments)]
+pub async fn validate_response_with_options<S, R>(
+    session_transcript: S,
+    trust_anchor_registry: TrustAnchorRegistry,
+    x5chain: X5Chain,
+    document: Document,
+    namespaces: BTreeMap<String, serde_json::Value>,
+    doc_types: Vec<String>,
+    revocation_fetcher: &R,
+    e_reader_key_private: [u8; 32],
+    options: &ValidationOptions,
 ) -> ResponseAuthenticationOutcome
 where
     S: SessionTranscript + Clone,
@@ -63,7 +104,12 @@ where
     }
 
     let validation_outcome = x509::validation::ValidationRuleset::Mdl
-        .validate(&x5chain, &trust_anchor_registry, revocation_fetcher)
+        .validate_with_options(
+            &x5chain,
+            &trust_anchor_registry,
+            revocation_fetcher,
+            options,
+        )
         .await;
 
     // Add revocation errors as warnings (non-fatal)
@@ -76,8 +122,17 @@ where
 
     if validation_outcome.errors.is_empty() {
         match issuer_authentication(x5chain, &document.issuer_signed) {
-            Ok(_) => {
+            Ok(mso) => {
                 validated_response.issuer_authentication = AuthenticationStatus::Valid;
+
+                // The MSO signature is trusted, so its validity window can be trusted.
+                // Reject expired / not-yet-valid credentials (ISO 18013-5 §9.1.2.4).
+                if let Err(e) = check_mso_validity(&mso.validity_info, options.validation_time()) {
+                    validated_response.errors.insert(
+                        "mso_validity_errors".to_string(),
+                        json!(vec![format!("{e}")]),
+                    );
+                }
             }
             Err(e) => {
                 validated_response.issuer_authentication = AuthenticationStatus::Invalid;


### PR DESCRIPTION
MSO validity period was missing, meaning a holder could disclose an outdated MSO and it would be accepted.

This vulnerability couldn't be exploited in production as issuers only issue mDLs to known wallets that haven't been tampered with (through app attestations).