### PR TITLE
Accept empty issuerSigned nameSpaces as no disclosure

### DIFF
--- a/src/definitions/issuer_signed.rs
+++ b/src/definitions/issuer_signed.rs
@@ -16,7 +16,8 @@ use crate::definitions::{
     DigestId,
 };
 use coset::CoseSign1;
-use serde::{Deserialize, Serialize};
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
+use std::collections::BTreeMap;
 
 /// Represents an issuer-signed object.
 ///
@@ -26,13 +27,54 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IssuerSigned {
-    #[serde(skip_serializing_if = "Option::is_none", rename = "nameSpaces")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_issuer_namespaces",
+        skip_serializing_if = "Option::is_none",
+        rename = "nameSpaces"
+    )]
     pub namespaces: Option<IssuerNamespaces>,
     pub issuer_auth: MaybeTagged<CoseSign1>,
 }
 
 pub type IssuerNamespaces = NonEmptyMap<String, NonEmptyVec<IssuerSignedItemBytes>>;
 pub type IssuerSignedItemBytes = Tag24<IssuerSignedItem>;
+
+/// Decode the optional disclosure map used in an `IssuerSigned` response.
+///
+/// ISO 18013-5 models `nameSpaces` as optional. Some interoperable wallets,
+/// including the OpenID Foundation conformance wallet, encode a presentation
+/// with no disclosed issuer-signed items as an empty map instead of omitting
+/// the field. Treat those two encodings as the same semantic value. Non-empty
+/// namespace maps remain strict: every included namespace must still contain
+/// at least one signed item.
+fn deserialize_optional_issuer_namespaces<'de, D>(
+    deserializer: D,
+) -> Result<Option<IssuerNamespaces>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let Some(namespaces) =
+        Option::<BTreeMap<String, Vec<IssuerSignedItemBytes>>>::deserialize(deserializer)?
+    else {
+        return Ok(None);
+    };
+    if namespaces.is_empty() {
+        return Ok(None);
+    }
+
+    let namespaces = namespaces
+        .into_iter()
+        .map(|(name, items)| {
+            NonEmptyVec::try_from(items)
+                .map(|items| (name, items))
+                .map_err(D::Error::custom)
+        })
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    NonEmptyMap::try_from(namespaces)
+        .map(Some)
+        .map_err(D::Error::custom)
+}
 
 /// Represents an item signed by the issuer.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -56,6 +98,7 @@ pub struct IssuerSignedItem {
 mod test {
     use super::IssuerSigned;
     use crate::cbor;
+    use ciborium::Value;
     use hex::FromHex;
 
     static ISSUER_SIGNED_CBOR: &str = include_str!("../../test/definitions/issuer_signed.cbor");
@@ -72,5 +115,49 @@ mod test {
             cbor_bytes, roundtripped_bytes,
             "original cbor and re-serialized IssuerSigned do not match"
         );
+    }
+
+    #[test]
+    fn empty_issuer_namespaces_are_treated_as_not_disclosed() {
+        let cbor_bytes =
+            <Vec<u8>>::from_hex(ISSUER_SIGNED_CBOR).expect("unable to convert cbor hex to bytes");
+        let mut value: Value =
+            cbor::from_slice(&cbor_bytes).expect("unable to decode issuer signed fixture");
+        let Value::Map(entries) = &mut value else {
+            panic!("issuer signed fixture must be a CBOR map");
+        };
+        let namespaces = entries
+            .iter_mut()
+            .find(|(key, _)| key == &Value::Text("nameSpaces".to_string()))
+            .expect("issuer signed fixture must contain nameSpaces");
+        namespaces.1 = Value::Map(Vec::new());
+        let cbor_bytes = cbor::to_vec(&value).expect("unable to encode empty disclosure map");
+
+        let signed: IssuerSigned =
+            cbor::from_slice(&cbor_bytes).expect("empty disclosure map must be accepted");
+
+        assert!(signed.namespaces.is_none());
+    }
+
+    #[test]
+    fn non_empty_namespace_with_no_items_remains_invalid() {
+        let cbor_bytes =
+            <Vec<u8>>::from_hex(ISSUER_SIGNED_CBOR).expect("unable to convert cbor hex to bytes");
+        let mut value: Value =
+            cbor::from_slice(&cbor_bytes).expect("unable to decode issuer signed fixture");
+        let Value::Map(entries) = &mut value else {
+            panic!("issuer signed fixture must be a CBOR map");
+        };
+        let namespaces = entries
+            .iter_mut()
+            .find(|(key, _)| key == &Value::Text("nameSpaces".to_string()))
+            .expect("issuer signed fixture must contain nameSpaces");
+        namespaces.1 = Value::Map(vec![(
+            Value::Text("org.iso.18013.5.1".to_string()),
+            Value::Array(Vec::new()),
+        )]);
+        let cbor_bytes = cbor::to_vec(&value).expect("unable to encode invalid disclosure map");
+
+        assert!(cbor::from_slice::<IssuerSigned>(&cbor_bytes).is_err());
     }
 }


### PR DESCRIPTION
## Summary

Treat an explicitly present but empty `issuerSigned.nameSpaces` map as no disclosed issuer-signed items (`None`). ISO 18013-5 presentations can legitimately disclose no issuer-signed claims, and the official OIDF wallet emits this representation when the verifier requests no claims.

Non-empty maps remain strict: every namespace must contain at least one item.

## Validation

- `cargo test` (161 passed, 3 ignored, plus integration/doc tests)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

This was first exercised against the official OIDF verifier suite and independently reproduced with its 3,578-byte DeviceResponse.